### PR TITLE
feat(chat): implement subagent input and compact boundary display items

### DIFF
--- a/src/renderer/components/chat/DisplayItemList.tsx
+++ b/src/renderer/components/chat/DisplayItemList.tsx
@@ -1,11 +1,25 @@
 import React, { useCallback, useState } from 'react';
 
+import {
+  CODE_BG,
+  CODE_BORDER,
+  COLOR_TEXT_MUTED,
+  TOOL_CALL_BG,
+  TOOL_CALL_BORDER,
+  TOOL_CALL_TEXT,
+} from '@renderer/constants/cssVariables';
+import { formatTokensCompact } from '@renderer/utils/formatters';
+import { format } from 'date-fns';
+import { ChevronRight, Layers, MailOpen } from 'lucide-react';
+
+import { BaseItem } from './items/BaseItem';
 import { LinkedToolItem } from './items/LinkedToolItem';
 import { SlashItem } from './items/SlashItem';
 import { SubagentItem } from './items/SubagentItem';
 import { TeammateMessageItem } from './items/TeammateMessageItem';
 import { TextItem } from './items/TextItem';
 import { ThinkingItem } from './items/ThinkingItem';
+import { MarkdownViewer } from './viewers/MarkdownViewer';
 
 import type { AIGroupDisplayItem } from '@renderer/types/groups';
 import type { TriggerColor } from '@shared/constants/triggerColors';
@@ -204,6 +218,103 @@ export const DisplayItemList = ({
                 isExpanded={expandedItemIds.has(itemKey)}
                 onReplyHover={handleReplyHover}
               />
+            );
+            break;
+          }
+
+          case 'subagent_input': {
+            itemKey = `input-${index}`;
+            const inputContent = item.content;
+            const inputTokenCount = item.tokenCount;
+            element = (
+              <BaseItem
+                icon={<MailOpen className="size-4" />}
+                label="Input"
+                summary={truncateText(inputContent, 80)}
+                tokenCount={inputTokenCount}
+                onClick={() => onItemClick(itemKey)}
+                isExpanded={expandedItemIds.has(itemKey)}
+              >
+                <MarkdownViewer content={inputContent} copyable />
+              </BaseItem>
+            );
+            break;
+          }
+
+          case 'compact_boundary': {
+            itemKey = `compact-${index}`;
+            const compactContent = item.content;
+            const compactExpanded = expandedItemIds.has(itemKey);
+            element = (
+              <div>
+                <button
+                  onClick={() => onItemClick(itemKey)}
+                  className="group flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 transition-all duration-200"
+                  style={{
+                    backgroundColor: TOOL_CALL_BG,
+                    border: `1px solid ${TOOL_CALL_BORDER}`,
+                  }}
+                  aria-expanded={compactExpanded}
+                >
+                  <div
+                    className="flex shrink-0 items-center gap-1.5"
+                    style={{ color: TOOL_CALL_TEXT }}
+                  >
+                    <ChevronRight
+                      size={14}
+                      className={`transition-transform duration-200 ${compactExpanded ? 'rotate-90' : ''}`}
+                    />
+                    <Layers size={14} />
+                  </div>
+                  <span className="shrink-0 text-xs font-medium" style={{ color: TOOL_CALL_TEXT }}>
+                    Compacted
+                  </span>
+                  {item.tokenDelta && (
+                    <span
+                      className="min-w-0 truncate text-[11px] tabular-nums"
+                      style={{ color: COLOR_TEXT_MUTED }}
+                    >
+                      {formatTokensCompact(item.tokenDelta.preCompactionTokens)} →{' '}
+                      {formatTokensCompact(item.tokenDelta.postCompactionTokens)}
+                      <span style={{ color: '#4ade80' }}>
+                        {' '}
+                        ({formatTokensCompact(Math.abs(item.tokenDelta.delta))} freed)
+                      </span>
+                    </span>
+                  )}
+                  <span
+                    className="shrink-0 rounded px-1.5 py-0.5 text-[10px]"
+                    style={{
+                      backgroundColor: 'rgba(99, 102, 241, 0.15)',
+                      color: '#818cf8',
+                    }}
+                  >
+                    Phase {item.phaseNumber}
+                  </span>
+                  <span
+                    className="ml-auto shrink-0 text-[11px]"
+                    style={{ color: COLOR_TEXT_MUTED }}
+                  >
+                    {format(new Date(item.timestamp), 'h:mm:ss a')}
+                  </span>
+                </button>
+                {compactExpanded && compactContent && (
+                  <div
+                    className="mt-1 overflow-hidden rounded-lg"
+                    style={{
+                      backgroundColor: CODE_BG,
+                      border: `1px solid ${CODE_BORDER}`,
+                    }}
+                  >
+                    <div
+                      className="max-h-64 overflow-y-auto border-l-2 px-3 py-2"
+                      style={{ borderColor: 'var(--chat-ai-border)' }}
+                    >
+                      <MarkdownViewer content={compactContent} copyable />
+                    </div>
+                  </div>
+                )}
+              </div>
             );
             break;
           }

--- a/src/renderer/components/chat/items/ExecutionTrace.tsx
+++ b/src/renderer/components/chat/items/ExecutionTrace.tsx
@@ -1,9 +1,24 @@
 import React, { useState } from 'react';
 
-import { CARD_ICON_MUTED } from '@renderer/constants/cssVariables';
+import {
+  CARD_ICON_MUTED,
+  CODE_BG,
+  CODE_BORDER,
+  COLOR_TEXT_MUTED,
+  TOOL_CALL_BG,
+  TOOL_CALL_BORDER,
+  TOOL_CALL_TEXT,
+} from '@renderer/constants/cssVariables';
 import { truncateText } from '@renderer/utils/aiGroupEnhancer';
+import { formatTokensCompact } from '@renderer/utils/formatters';
+import { format } from 'date-fns';
+import { ChevronRight, Layers, MailOpen } from 'lucide-react';
 
+import { MarkdownViewer } from '../viewers/MarkdownViewer';
+
+import { BaseItem } from './BaseItem';
 import { LinkedToolItem } from './LinkedToolItem';
+import { TeammateMessageItem } from './TeammateMessageItem';
 import { TextItem } from './TextItem';
 import { ThinkingItem } from './ThinkingItem';
 
@@ -141,6 +156,115 @@ export const ExecutionTrace: React.FC<ExecutionTraceProps> = ({
                 Nested: {item.subagent.description ?? item.subagent.id}
               </div>
             );
+
+          case 'subagent_input': {
+            const itemId = `subagent-input-${index}`;
+            const isExpanded = expandedItemId === itemId;
+            return (
+              <BaseItem
+                key={itemId}
+                icon={<MailOpen className="size-4" />}
+                label="Input"
+                summary={truncateText(item.content, 80)}
+                tokenCount={item.tokenCount}
+                onClick={() => handleItemClick(itemId)}
+                isExpanded={isExpanded}
+              >
+                <MarkdownViewer content={item.content} copyable />
+              </BaseItem>
+            );
+          }
+
+          case 'teammate_message': {
+            const itemId = `subagent-teammate-${item.teammateMessage.id}-${index}`;
+            const isExpanded = expandedItemId === itemId;
+            return (
+              <TeammateMessageItem
+                key={itemId}
+                teammateMessage={item.teammateMessage}
+                onClick={() => handleItemClick(itemId)}
+                isExpanded={isExpanded}
+              />
+            );
+          }
+
+          case 'compact_boundary': {
+            const itemId = `subagent-compact-${index}`;
+            const isExpanded = expandedItemId === itemId;
+            return (
+              <div key={itemId}>
+                {/* Header — matches CompactBoundary.tsx amber styling */}
+                <button
+                  onClick={() => handleItemClick(itemId)}
+                  className="group flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 transition-all duration-200"
+                  style={{
+                    backgroundColor: TOOL_CALL_BG,
+                    border: `1px solid ${TOOL_CALL_BORDER}`,
+                  }}
+                  aria-expanded={isExpanded}
+                >
+                  <div
+                    className="flex shrink-0 items-center gap-1.5"
+                    style={{ color: TOOL_CALL_TEXT }}
+                  >
+                    <ChevronRight
+                      size={14}
+                      className={`transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+                    />
+                    <Layers size={14} />
+                  </div>
+                  <span className="shrink-0 text-xs font-medium" style={{ color: TOOL_CALL_TEXT }}>
+                    Compacted
+                  </span>
+                  {item.tokenDelta && (
+                    <span
+                      className="min-w-0 truncate text-[11px] tabular-nums"
+                      style={{ color: COLOR_TEXT_MUTED }}
+                    >
+                      {formatTokensCompact(item.tokenDelta.preCompactionTokens)} →{' '}
+                      {formatTokensCompact(item.tokenDelta.postCompactionTokens)}
+                      <span style={{ color: '#4ade80' }}>
+                        {' '}
+                        ({formatTokensCompact(Math.abs(item.tokenDelta.delta))} freed)
+                      </span>
+                    </span>
+                  )}
+                  <span
+                    className="shrink-0 rounded px-1.5 py-0.5 text-[10px]"
+                    style={{
+                      backgroundColor: 'rgba(99, 102, 241, 0.15)',
+                      color: '#818cf8',
+                    }}
+                  >
+                    Phase {item.phaseNumber}
+                  </span>
+                  <span
+                    className="ml-auto shrink-0 text-[11px]"
+                    style={{ color: COLOR_TEXT_MUTED }}
+                  >
+                    {format(new Date(item.timestamp), 'h:mm:ss a')}
+                  </span>
+                </button>
+                {/* Expanded content */}
+                {isExpanded && item.content && (
+                  <div
+                    className="mt-1 overflow-hidden rounded-lg"
+                    style={{
+                      backgroundColor: CODE_BG,
+                      border: `1px solid ${CODE_BORDER}`,
+                    }}
+                  >
+                    <div
+                      className="max-h-64 overflow-y-auto border-l-2 px-3 py-2"
+                      style={{ borderColor: 'var(--chat-ai-border)' }}
+                    >
+                      <MarkdownViewer content={item.content} copyable />
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          }
 
           default:
             return null;

--- a/src/renderer/types/groups.ts
+++ b/src/renderer/types/groups.ts
@@ -253,7 +253,15 @@ export type AIGroupDisplayItem =
   | { type: 'subagent'; subagent: Process }
   | { type: 'output'; content: string; timestamp: Date; tokenCount?: number }
   | { type: 'slash'; slash: SlashItem }
-  | { type: 'teammate_message'; teammateMessage: TeammateMessage };
+  | { type: 'teammate_message'; teammateMessage: TeammateMessage }
+  | { type: 'subagent_input'; content: string; timestamp: Date; tokenCount?: number }
+  | {
+      type: 'compact_boundary';
+      content: string;
+      timestamp: Date;
+      tokenDelta?: CompactionTokenDelta;
+      phaseNumber: number;
+    };
 
 /**
  * The last output in an AI Group - what user sees as "the answer".

--- a/src/renderer/utils/aiGroupHelpers.ts
+++ b/src/renderer/utils/aiGroupHelpers.ts
@@ -7,7 +7,7 @@
 import { createLogger } from '@shared/utils/logger';
 import { estimateTokens } from '@shared/utils/tokenFormatting';
 
-import type { Process } from '../types/data';
+import type { ParsedMessage, PhaseTokenBreakdown, Process } from '../types/data';
 import type { LinkedToolItem } from '../types/groups';
 
 const logger = createLogger('Util:aiGroupHelpers');
@@ -97,4 +97,112 @@ export function attachMainSessionImpact(
     }
   }
   return subagents;
+}
+
+/**
+ * Computes multi-phase context breakdown for a subagent session.
+ * Mirrors the algorithm in src/main/utils/jsonl.ts:500-576.
+ *
+ * Tracks assistant input tokens across compaction events to compute
+ * per-phase contribution and total consumption across all phases.
+ *
+ * @param messages - Subagent's ParsedMessages
+ * @returns Phase breakdown with total consumption, or null if no usage data
+ */
+export function computeSubagentPhaseBreakdown(messages: ParsedMessage[]): {
+  phases: PhaseTokenBreakdown[];
+  totalConsumption: number;
+  compactionCount: number;
+} | null {
+  let lastMainAssistantInputTokens = 0;
+  let awaitingPostCompaction = false;
+  const compactionPhases: { pre: number; post: number }[] = [];
+
+  for (const msg of messages) {
+    // Track assistant input tokens.
+    // Unlike jsonl.ts, we don't filter by isSidechain here because subagent messages
+    // all have isSidechain=true (from the parent session's perspective).
+    if (msg.type === 'assistant' && msg.model !== '<synthetic>') {
+      const inputTokens =
+        (msg.usage?.input_tokens ?? 0) +
+        (msg.usage?.cache_read_input_tokens ?? 0) +
+        (msg.usage?.cache_creation_input_tokens ?? 0);
+      if (inputTokens > 0) {
+        if (awaitingPostCompaction && compactionPhases.length > 0) {
+          compactionPhases[compactionPhases.length - 1].post = inputTokens;
+          awaitingPostCompaction = false;
+        }
+        lastMainAssistantInputTokens = inputTokens;
+      }
+    }
+
+    // Detect compaction events
+    if (msg.isCompactSummary) {
+      compactionPhases.push({ pre: lastMainAssistantInputTokens, post: 0 });
+      awaitingPostCompaction = true;
+    }
+  }
+
+  if (lastMainAssistantInputTokens <= 0) {
+    return null;
+  }
+
+  let phaseBreakdown: PhaseTokenBreakdown[];
+
+  if (compactionPhases.length === 0) {
+    // No compaction: single phase
+    phaseBreakdown = [
+      {
+        phaseNumber: 1,
+        contribution: lastMainAssistantInputTokens,
+        peakTokens: lastMainAssistantInputTokens,
+      },
+    ];
+    return {
+      phases: phaseBreakdown,
+      totalConsumption: lastMainAssistantInputTokens,
+      compactionCount: 0,
+    };
+  }
+
+  phaseBreakdown = [];
+  let total = 0;
+
+  // Phase 1: tokens up to first compaction
+  const phase1Contribution = compactionPhases[0].pre;
+  total += phase1Contribution;
+  phaseBreakdown.push({
+    phaseNumber: 1,
+    contribution: phase1Contribution,
+    peakTokens: compactionPhases[0].pre,
+    postCompaction: compactionPhases[0].post,
+  });
+
+  // Middle phases: contribution = pre[i] - post[i-1]
+  for (let i = 1; i < compactionPhases.length; i++) {
+    const contribution = compactionPhases[i].pre - compactionPhases[i - 1].post;
+    total += contribution;
+    phaseBreakdown.push({
+      phaseNumber: i + 1,
+      contribution,
+      peakTokens: compactionPhases[i].pre,
+      postCompaction: compactionPhases[i].post,
+    });
+  }
+
+  // Last phase: final tokens - last post-compaction
+  const lastPhase = compactionPhases[compactionPhases.length - 1];
+  const lastContribution = lastMainAssistantInputTokens - lastPhase.post;
+  total += lastContribution;
+  phaseBreakdown.push({
+    phaseNumber: compactionPhases.length + 1,
+    contribution: lastContribution,
+    peakTokens: lastMainAssistantInputTokens,
+  });
+
+  return {
+    phases: phaseBreakdown,
+    totalConsumption: total,
+    compactionCount: compactionPhases.length,
+  };
 }

--- a/src/renderer/utils/displaySummary.ts
+++ b/src/renderer/utils/displaySummary.ts
@@ -26,6 +26,8 @@ export function buildSummary(items: AIGroupDisplayItem[]): string {
     subagent: 0,
     slash: 0,
     teammate_message: 0,
+    subagent_input: 0,
+    compact_boundary: 0,
   };
   const teammateNames = new Set<string>();
 
@@ -60,6 +62,11 @@ export function buildSummary(items: AIGroupDisplayItem[]): string {
   if (counts.teammate_message > 0) {
     parts.push(
       `${counts.teammate_message} teammate ${counts.teammate_message === 1 ? 'message' : 'messages'}`
+    );
+  }
+  if (counts.compact_boundary > 0) {
+    parts.push(
+      `${counts.compact_boundary} ${counts.compact_boundary === 1 ? 'compaction' : 'compactions'}`
     );
   }
 


### PR DESCRIPTION
- Added support for rendering 'subagent_input' and 'compact_boundary' types in the chat display components.
- Introduced a new `MarkdownViewer` for displaying content in both item types.
- Enhanced the `MetricsPill` and `SubagentItem` components to include phase breakdowns and isolated usage metrics.
- Updated the `AIGroupDisplayItem` type to accommodate new item types and their properties.
- Implemented logic to compute and display token consumption across multiple phases for subagents.

Closes #8
Closes #9