### PR TITLE
Integrate Copilot sessions: detect, parse, and surface events

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,7 +22,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 
 import { initializeIpcHandlers, removeIpcHandlers } from './ipc/handlers';
-import { getProjectsBasePath, getTodosBasePath } from './utils/pathDecoder';
+import { getCopilotSessionsBasePath, getProjectsBasePath, getTodosBasePath } from './utils/pathDecoder';
 
 // Window icon path for non-mac platforms.
 const getWindowIconPath = (): string | undefined => {
@@ -196,12 +196,15 @@ function reconfigureLocalContextForClaudeRoot(): void {
       currentLocal.stopFileWatcher();
     }
 
+    const copilotSessionsDir = getCopilotSessionsBasePath();
+
     const replacementLocal = new ServiceContext({
       id: 'local',
       type: 'local',
       fsProvider: new LocalFileSystemProvider(),
       projectsDir,
       todosDir,
+      copilotSessionsDir,
     });
 
     if (notificationManager) {
@@ -237,6 +240,7 @@ function initializeServices(): void {
 
   const localProjectsDir = getProjectsBasePath();
   const localTodosDir = getTodosBasePath();
+  const localCopilotSessionsDir = getCopilotSessionsBasePath();
 
   // Create local context
   const localContext = new ServiceContext({
@@ -245,6 +249,7 @@ function initializeServices(): void {
     fsProvider: new LocalFileSystemProvider(),
     projectsDir: localProjectsDir,
     todosDir: localTodosDir,
+    copilotSessionsDir: localCopilotSessionsDir,
   });
 
   // Register and start local context
@@ -271,6 +276,9 @@ function initializeServices(): void {
     rewire: rewireContextEvents,
     full: onContextSwitched,
     onClaudeRootPathUpdated: (_claudeRootPath: string | null) => {
+      reconfigureLocalContextForClaudeRoot();
+    },
+    onCopilotRootPathUpdated: (_copilotRootPath: string | null) => {
       reconfigureLocalContextForClaudeRoot();
     },
   });

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -69,6 +69,7 @@ export function initializeIpcHandlers(
     rewire: (context: ServiceContext) => void;
     full: (context: ServiceContext) => void;
     onClaudeRootPathUpdated: (claudeRootPath: string | null) => Promise<void> | void;
+    onCopilotRootPathUpdated: (copilotRootPath: string | null) => Promise<void> | void;
   }
 ): void {
   // Initialize domain handlers with registry
@@ -81,6 +82,7 @@ export function initializeIpcHandlers(
   initializeContextHandlers(registry, contextCallbacks.rewire);
   initializeConfigHandlers({
     onClaudeRootPathUpdated: contextCallbacks.onClaudeRootPathUpdated,
+    onCopilotRootPathUpdated: contextCallbacks.onCopilotRootPathUpdated,
   });
 
   // Register all handlers

--- a/src/main/services/discovery/SessionSearcher.ts
+++ b/src/main/services/discovery/SessionSearcher.ts
@@ -19,7 +19,7 @@ import {
   type SemanticStep,
 } from '@main/types';
 import { parseJsonlFile } from '@main/utils/jsonl';
-import { extractBaseDir, extractSessionId } from '@main/utils/pathDecoder';
+import { extractBaseDir, extractSessionId, isSessionFileName } from '@main/utils/pathDecoder';
 import { sanitizeDisplayContent } from '@shared/utils/contentSanitizer';
 import { createLogger } from '@shared/utils/logger';
 import {
@@ -98,7 +98,7 @@ export class SessionSearcher {
       // Get all session files
       const entries = await this.fsProvider.readdir(projectPath);
       const sessionEntries = entries.filter((entry) => {
-        if (!entry.isFile() || !entry.name.endsWith('.jsonl')) return false;
+        if (!entry.isFile() || !isSessionFileName(entry.name)) return false;
         // Filter to only sessions belonging to this subproject
         if (sessionFilter) {
           const sessionId = extractSessionId(entry.name);

--- a/src/main/services/infrastructure/ServiceContext.ts
+++ b/src/main/services/infrastructure/ServiceContext.ts
@@ -43,6 +43,8 @@ export interface ServiceContextConfig {
   projectsDir?: string;
   /** Todos directory path (defaults to ~/.claude/todos) */
   todosDir?: string;
+  /** Copilot session-state directory path (defaults to ~/.copilot/session-state) */
+  copilotSessionsDir?: string | null;
 }
 
 /**
@@ -92,7 +94,8 @@ export class ServiceContext {
     this.projectScanner = new ProjectScanner(
       config.projectsDir,
       config.todosDir,
-      config.fsProvider
+      config.fsProvider,
+      config.copilotSessionsDir
     );
 
     // 2. SessionParser - depends on ProjectScanner

--- a/src/main/services/parsing/SessionParser.ts
+++ b/src/main/services/parsing/SessionParser.ts
@@ -22,6 +22,7 @@ import {
   getTaskCalls,
   parseJsonlFile,
 } from '@main/utils/jsonl';
+import { extractSessionId } from '@main/utils/pathDecoder';
 import * as path from 'path';
 
 import { type ProjectScanner } from '../discovery/ProjectScanner';
@@ -66,7 +67,10 @@ export class SessionParser {
    * Parse a session JSONL file and return structured data.
    */
   async parseSession(projectId: string, sessionId: string): Promise<ParsedSession> {
-    const sessionPath = this.projectScanner.getSessionPath(projectId, sessionId);
+    const sessionFiles = await this.projectScanner.listSessionFiles(projectId);
+    const sessionPath =
+      sessionFiles.find((file) => extractSessionId(path.basename(file)) === sessionId) ??
+      this.projectScanner.getSessionPath(projectId, sessionId);
     return this.parseSessionFile(sessionPath);
   }
 

--- a/src/main/types/domain.ts
+++ b/src/main/types/domain.ts
@@ -57,6 +57,8 @@ export interface Project {
   createdAt: number;
   /** Unix timestamp of most recent session activity */
   mostRecentSession?: number;
+  /** Session source: 'claude' for Claude Code, 'copilot' for GitHub Copilot */
+  source?: 'claude' | 'copilot';
 }
 
 /**
@@ -103,6 +105,8 @@ export interface Session {
   gitBranch?: string;
   /** Metadata completeness level */
   metadataLevel?: SessionMetadataLevel;
+  /** Session source: 'claude' for Claude Code, 'copilot' for GitHub Copilot */
+  source?: 'claude' | 'copilot';
   /** Total context consumed (compaction-aware sum of all phases) */
   contextConsumption?: number;
   /** Number of compaction events */
@@ -209,6 +213,8 @@ export interface RepositoryGroup {
   mostRecentSession?: number;
   /** Total session count across all worktrees */
   totalSessions: number;
+  /** Session source: 'claude' for Claude Code, 'copilot' for GitHub Copilot */
+  source?: 'claude' | 'copilot';
 }
 
 // =============================================================================

--- a/src/preload/constants/ipcChannels.ts
+++ b/src/preload/constants/ipcChannels.ts
@@ -56,6 +56,12 @@ export const CONFIG_SELECT_CLAUDE_ROOT_FOLDER = 'config:selectClaudeRootFolder';
 /** Get effective/default Claude root folder info */
 export const CONFIG_GET_CLAUDE_ROOT_INFO = 'config:getClaudeRootInfo';
 
+/** Select local Copilot root folder */
+export const CONFIG_SELECT_COPILOT_ROOT_FOLDER = 'config:selectCopilotRootFolder';
+
+/** Get effective/default Copilot root folder info */
+export const CONFIG_GET_COPILOT_ROOT_INFO = 'config:getCopilotRootInfo';
+
 /** Find WSL Claude root candidates (Windows only) */
 export const CONFIG_FIND_WSL_CLAUDE_ROOTS = 'config:findWslClaudeRoots';
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,7 @@ import {
   CONFIG_FIND_WSL_CLAUDE_ROOTS,
   CONFIG_GET,
   CONFIG_GET_CLAUDE_ROOT_INFO,
+  CONFIG_GET_COPILOT_ROOT_INFO,
   CONFIG_GET_TRIGGERS,
   CONFIG_HIDE_SESSION,
   CONFIG_HIDE_SESSIONS,
@@ -44,6 +45,7 @@ import {
   CONFIG_REMOVE_IGNORE_REPOSITORY,
   CONFIG_REMOVE_TRIGGER,
   CONFIG_SELECT_CLAUDE_ROOT_FOLDER,
+  CONFIG_SELECT_COPILOT_ROOT_FOLDER,
   CONFIG_SELECT_FOLDERS,
   CONFIG_SNOOZE,
   CONFIG_TEST_TRIGGER,
@@ -59,6 +61,8 @@ import type {
   ClaudeRootFolderSelection,
   ClaudeRootInfo,
   ContextInfo,
+  CopilotRootFolderSelection,
+  CopilotRootInfo,
   ElectronAPI,
   HttpServerStatus,
   NotificationTrigger,
@@ -283,6 +287,14 @@ const electronAPI: ElectronAPI = {
     },
     getClaudeRootInfo: async (): Promise<ClaudeRootInfo> => {
       return invokeIpcWithResult<ClaudeRootInfo>(CONFIG_GET_CLAUDE_ROOT_INFO);
+    },
+    selectCopilotRootFolder: async (): Promise<CopilotRootFolderSelection | null> => {
+      return invokeIpcWithResult<CopilotRootFolderSelection | null>(
+        CONFIG_SELECT_COPILOT_ROOT_FOLDER
+      );
+    },
+    getCopilotRootInfo: async (): Promise<CopilotRootInfo> => {
+      return invokeIpcWithResult<CopilotRootInfo>(CONFIG_GET_COPILOT_ROOT_INFO);
     },
     findWslClaudeRoots: async (): Promise<WslClaudeRootCandidate[]> => {
       return invokeIpcWithResult<WslClaudeRootCandidate[]>(CONFIG_FIND_WSL_CLAUDE_ROOTS);

--- a/src/renderer/api/httpClient.ts
+++ b/src/renderer/api/httpClient.ts
@@ -14,6 +14,8 @@ import type {
   ConfigAPI,
   ContextInfo,
   ConversationGroup,
+  CopilotRootFolderSelection,
+  CopilotRootInfo,
   ElectronAPI,
   FileChangeEvent,
   HttpServerAPI,
@@ -423,6 +425,19 @@ export class HttpAPIClient implements ElectronAPI {
         defaultPath: fallbackPath,
         resolvedPath: fallbackPath,
         customPath: config.general.claudeRootPath,
+      };
+    },
+    selectCopilotRootFolder: async (): Promise<CopilotRootFolderSelection | null> => {
+      console.warn('[HttpAPIClient] selectCopilotRootFolder is not available in browser mode');
+      return null;
+    },
+    getCopilotRootInfo: async (): Promise<CopilotRootInfo> => {
+      const config = await this.config.get();
+      const fallbackPath = config.general.copilotRootPath ?? '~/.copilot/session-state';
+      return {
+        defaultPath: fallbackPath,
+        resolvedPath: fallbackPath,
+        customPath: config.general.copilotRootPath,
       };
     },
     findWslClaudeRoots: async (): Promise<WslClaudeRootCandidate[]> => {

--- a/src/renderer/components/dashboard/DashboardView.tsx
+++ b/src/renderer/components/dashboard/DashboardView.tsx
@@ -16,7 +16,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 const logger = createLogger('Component:DashboardView');
 import { formatDistanceToNow } from 'date-fns';
-import { Command, FolderGit2, FolderOpen, GitBranch, Search, Settings } from 'lucide-react';
+import { Command, FolderGit2, FolderOpen, GitBranch, Search, Settings, Sparkles } from 'lucide-react';
 
 import type { RepositoryGroup } from '@renderer/types/data';
 
@@ -162,8 +162,19 @@ const RepositoryCard = ({
       } `}
     >
       {/* Icon with subtle border */}
-      <div className="mb-3 flex size-8 items-center justify-center rounded-sm border border-border bg-surface-overlay transition-colors duration-300 group-hover:border-border-emphasis">
-        <FolderGit2 className="size-4 text-text-secondary transition-colors group-hover:text-text" />
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex size-8 items-center justify-center rounded-sm border border-border bg-surface-overlay transition-colors duration-300 group-hover:border-border-emphasis">
+          {repo.source === 'copilot' ? (
+            <Sparkles className="size-4 text-purple-400 transition-colors group-hover:text-purple-300" />
+          ) : (
+            <FolderGit2 className="size-4 text-text-secondary transition-colors group-hover:text-text" />
+          )}
+        </div>
+        {repo.source === 'copilot' && (
+          <span className="rounded-full bg-purple-500/15 px-2 py-0.5 text-[9px] font-medium text-purple-400">
+            Copilot
+          </span>
+        )}
       </div>
 
       {/* Project name */}

--- a/src/renderer/components/settings/hooks/useSettingsHandlers.ts
+++ b/src/renderer/components/settings/hooks/useSettingsHandlers.ts
@@ -287,6 +287,7 @@ export function useSettingsHandlers({
           theme: 'dark',
           defaultTab: 'dashboard',
           claudeRootPath: null,
+          copilotRootPath: null,
         },
         display: {
           showTimestamps: true,

--- a/src/renderer/components/sidebar/SessionItem.tsx
+++ b/src/renderer/components/sidebar/SessionItem.tsx
@@ -10,7 +10,7 @@ import { createPortal } from 'react-dom';
 import { useStore } from '@renderer/store';
 import { formatTokensCompact } from '@shared/utils/tokenFormatting';
 import { formatDistanceToNowStrict } from 'date-fns';
-import { EyeOff, MessageSquare, Pin } from 'lucide-react';
+import { EyeOff, MessageSquare, Pin, Sparkles } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 
 import { OngoingIndicator } from '../common/OngoingIndicator';
@@ -21,6 +21,7 @@ import type { PhaseTokenBreakdown, Session } from '@renderer/types/data';
 
 interface SessionItemProps {
   session: Session;
+  isLive?: boolean;
   isActive?: boolean;
   isPinned?: boolean;
   isHidden?: boolean;
@@ -132,6 +133,7 @@ const ConsumptionBadge = ({
 
 export const SessionItem = ({
   session,
+  isLive,
   isActive,
   isPinned,
   isHidden,
@@ -160,6 +162,7 @@ export const SessionItem = ({
   );
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const isSessionLive = isLive ?? session.isOngoing;
 
   const handleClick = (event: React.MouseEvent): void => {
     if (!activeProjectId) return;
@@ -264,7 +267,7 @@ export const SessionItem = ({
               className="size-3.5 shrink-0 accent-blue-500"
             />
           )}
-          {session.isOngoing && <OngoingIndicator />}
+          {isSessionLive && <OngoingIndicator />}
           {isPinned && <Pin className="size-2.5 shrink-0 text-blue-400" />}
           {isHidden && <EyeOff className="size-2.5 shrink-0 text-zinc-500" />}
           <span
@@ -275,11 +278,24 @@ export const SessionItem = ({
           </span>
         </div>
 
-        {/* Second line: message count + time + context consumption */}
+        {/* Second line: source badge + message count + time + context consumption */}
         <div
           className="mt-0.5 flex items-center gap-2 text-[10px] leading-tight"
           style={{ color: 'var(--color-text-muted)' }}
         >
+          {isSessionLive && (
+            <span
+              className="font-semibold uppercase tracking-wide"
+              style={{ color: 'var(--color-text-secondary)' }}
+            >
+              Live
+            </span>
+          )}
+          {session.source === 'copilot' && (
+            <span className="flex items-center gap-0.5 text-purple-400">
+              <Sparkles className="size-2.5" />
+            </span>
+          )}
           <span className="flex items-center gap-0.5">
             <MessageSquare className="size-2.5" />
             {session.messageCount}

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -91,6 +91,10 @@ export interface ConfigAPI {
   selectClaudeRootFolder: () => Promise<ClaudeRootFolderSelection | null>;
   /** Get resolved Claude root path info for local mode */
   getClaudeRootInfo: () => Promise<ClaudeRootInfo>;
+  /** Open native dialog to select local Copilot root folder */
+  selectCopilotRootFolder: () => Promise<CopilotRootFolderSelection | null>;
+  /** Get resolved Copilot root path info for local mode */
+  getCopilotRootInfo: () => Promise<CopilotRootInfo>;
   /** Find Windows WSL Claude root candidates (UNC paths) */
   findWslClaudeRoots: () => Promise<WslClaudeRootCandidate[]>;
   /** Opens the config JSON file in an external editor */
@@ -125,6 +129,22 @@ export interface ClaudeRootFolderSelection {
   isClaudeDirName: boolean;
   /** Whether selected folder contains a "projects" directory */
   hasProjectsDir: boolean;
+}
+
+export interface CopilotRootInfo {
+  /** Auto-detected default Copilot session-state path for this machine */
+  defaultPath: string;
+  /** Effective path currently used by local context */
+  resolvedPath: string;
+  /** Custom override path from settings (null means auto-detect) */
+  customPath: string | null;
+}
+
+export interface CopilotRootFolderSelection {
+  /** Selected directory absolute path */
+  path: string;
+  /** Whether the selected folder contains session JSONL files */
+  hasSessionFiles: boolean;
 }
 
 export interface WslClaudeRootCandidate {

--- a/src/shared/types/notifications.ts
+++ b/src/shared/types/notifications.ts
@@ -262,6 +262,8 @@ export interface AppConfig {
     defaultTab: 'dashboard' | 'last-session';
     /** Optional custom Claude root folder (auto-detected when null) */
     claudeRootPath: string | null;
+    /** Optional custom Copilot session-state folder (auto-detected when null) */
+    copilotRootPath: string | null;
   };
   /** Display and UI settings */
   display: {

--- a/test/main/services/discovery/ProjectPathResolver.test.ts
+++ b/test/main/services/discovery/ProjectPathResolver.test.ts
@@ -70,6 +70,16 @@ describe('ProjectPathResolver', () => {
     expect(resolved).toBe('C:/Users/test/my/repo');
   });
 
+  it('falls back to project directory path for non-encoded IDs', async () => {
+    const projectsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolver-projects-'));
+    tempDirs.push(projectsDir);
+
+    const resolver = new ProjectPathResolver(projectsDir);
+    const resolved = await resolver.resolveProjectPath('copilot-workspace');
+
+    expect(resolved).toBe(path.join(projectsDir, 'copilot-workspace'));
+  });
+
   it('invalidates cached paths by project', async () => {
     const projectsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolver-projects-'));
     tempDirs.push(projectsDir);

--- a/test/main/utils/jsonl.test.ts
+++ b/test/main/utils/jsonl.test.ts
@@ -3,7 +3,12 @@ import * as os from 'os';
 import * as path from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { analyzeSessionFileMetadata, calculateMetrics } from '../../../src/main/utils/jsonl';
+import {
+  analyzeSessionFileMetadata,
+  calculateMetrics,
+  parseJsonlFile,
+  parseJsonlLine,
+} from '../../../src/main/utils/jsonl';
 import type { ParsedMessage } from '../../../src/main/types';
 
 // Helper to create a minimal ParsedMessage
@@ -24,6 +29,57 @@ function createMessage(overrides: Partial<ParsedMessage> = {}): ParsedMessage {
 }
 
 describe('jsonl', () => {
+  describe('parsing compatibility', () => {
+    it('parses Copilot-style role/content JSONL lines', () => {
+      const line = JSON.stringify({
+        role: 'assistant',
+        content: 'Here is a response',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        id: 'copilot-msg-1',
+      });
+
+      const parsed = parseJsonlLine(line);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.type).toBe('assistant');
+      expect(parsed?.content).toBe('Here is a response');
+    });
+
+    it('parses Copilot-style JSON transcript files', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-json-'));
+      try {
+        const filePath = path.join(tempDir, 'session.json');
+        const transcript = {
+          requests: [
+            {
+              prompt: 'How do I test this?',
+              response: 'Use Vitest and assert the behavior.',
+              timestamp: '2026-01-01T10:00:00.000Z',
+              model: 'gpt-4.1',
+            },
+          ],
+        };
+
+        fs.writeFileSync(filePath, JSON.stringify(transcript), 'utf8');
+
+        const messages = await parseJsonlFile(filePath);
+        expect(messages).toHaveLength(2);
+        expect(messages[0].type).toBe('user');
+        expect(messages[1].type).toBe('assistant');
+      } finally {
+        try {
+          fs.rmSync(tempDir, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 200,
+          });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    });
+  });
+
   describe('calculateMetrics', () => {
     it('should return empty metrics for empty messages array', () => {
       const result = calculateMetrics([]);
@@ -182,5 +238,286 @@ describe('jsonl', () => {
         }
       }
     });
+
+    it('should extract title from agency session.start when no user message exists', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: {
+              copilotVersion: '0.0.375',
+              producer: 'agency',
+              sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+              startTime: '2026-01-17T15:21:19.143Z',
+              version: 1,
+            },
+            id: '11111111-2222-3333-4444-555555555555',
+            parentId: null,
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { message: 'Session shutting down' },
+            id: 'shutdown-1',
+            timestamp: '2026-01-17T15:25:00.000Z',
+            type: 'session.shutdown',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+
+        expect(result.firstUserMessage?.text).toBe('agency session');
+        expect(result.firstUserMessage?.timestamp).toBe('2026-01-17T15:21:19.143Z');
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
+
+    it('should extract user.message content for agency Copilot SDK events', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-user-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: { producer: 'agency', sessionId: 'sid-1' },
+            id: 'ev1',
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { content: 'Build a REST API for user management' },
+            id: 'ev2',
+            timestamp: '2026-01-17T15:21:20.000Z',
+            type: 'user.message',
+          }),
+          JSON.stringify({
+            data: { content: 'I will create the REST API with Express.js.' },
+            id: 'ev3',
+            timestamp: '2026-01-17T15:21:25.000Z',
+            type: 'assistant.message',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+
+        expect(result.firstUserMessage?.text).toBe('Build a REST API for user management');
+        expect(result.messageCount).toBe(1);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
+
+    it('should fall back to assistant.message when no user.message in Copilot events', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-assist-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: { producer: 'agency', sessionId: 'sid-2' },
+            id: 'ev1',
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { content: 'Starting analysis of the codebase...' },
+            id: 'ev3',
+            timestamp: '2026-01-17T15:21:25.000Z',
+            type: 'assistant.message',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+
+        // Should use assistant message as fallback instead of "agency session" from session.start
+        expect(result.firstUserMessage?.text).toBe('Starting analysis of the codebase...');
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
+
+    it('should count totalConversationalEntries for Copilot events', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-count-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: { producer: 'agency', sessionId: 'sid-3' },
+            id: 'ev1',
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { content: '' },
+            id: 'ev2',
+            timestamp: '2026-01-17T15:21:20.000Z',
+            type: 'user.message',
+          }),
+          JSON.stringify({
+            data: { content: 'Response text' },
+            id: 'ev3',
+            timestamp: '2026-01-17T15:21:25.000Z',
+            type: 'assistant.message',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+
+        // messageCount=0 (user.message has empty content), but totalConversationalEntries=1 (assistant)
+        // The return uses totalConversationalEntries as fallback
+        expect(result.messageCount).toBe(1);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
+
+    it('should mark Copilot session as not ongoing after session.shutdown', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-shutdown-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: { producer: 'agency', sessionId: 'sid-shutdown' },
+            id: 'ev1',
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { toolName: 'Read', input: { file: 'README.md' } },
+            id: 'ev2',
+            timestamp: '2026-01-17T15:21:20.000Z',
+            type: 'tool.execution_start',
+          }),
+          JSON.stringify({
+            data: { message: 'Session shutting down' },
+            id: 'ev3',
+            timestamp: '2026-01-17T15:21:21.000Z',
+            type: 'session.shutdown',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+        expect(result.isOngoing).toBe(false);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
+
+    it('should treat assistant.response as ending output in Copilot events', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-assistant-response-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: { producer: 'agency', sessionId: 'sid-assistant-response' },
+            id: 'ev1',
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { toolName: 'Read', input: { file: 'README.md' } },
+            id: 'ev2',
+            timestamp: '2026-01-17T15:21:20.000Z',
+            type: 'tool.execution_start',
+          }),
+          JSON.stringify({
+            data: { content: 'Completed analysis.' },
+            id: 'ev3',
+            timestamp: '2026-01-17T15:21:21.000Z',
+            type: 'assistant.response',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+        expect(result.isOngoing).toBe(false);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
+
+    it('should handle unknown Copilot event types with content via prefix matching', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-agency-unknown-'));
+      try {
+        const filePath = path.join(tempDir, 'session.jsonl');
+        const lines = [
+          JSON.stringify({
+            data: { producer: 'agency', sessionId: 'sid-4' },
+            id: 'ev1',
+            timestamp: '2026-01-17T15:21:19.143Z',
+            type: 'session.start',
+          }),
+          JSON.stringify({
+            data: { content: 'What is the meaning of life?' },
+            id: 'ev2',
+            timestamp: '2026-01-17T15:21:20.000Z',
+            type: 'user.request',
+          }),
+        ];
+        fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+
+        const result = await analyzeSessionFileMetadata(filePath);
+
+        // user.request should be handled by user.* prefix matching
+        expect(result.firstUserMessage?.text).toBe('What is the meaning of life?');
+        expect(result.messageCount).toBe(1);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      }
+    });
   });
-});
+
+  describe('parseJsonlLine - Copilot SDK event format', () => {
+    it('should parse session.start events', () => {
+      const line = JSON.stringify({
+        data: {
+          copilotVersion: '0.0.375',
+          producer: 'agency',
+          sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          startTime: '2026-01-17T15:21:19.143Z',
+          version: 1,
+        },
+        id: '11111111-2222-3333-4444-555555555555',
+        parentId: null,
+        timestamp: '2026-01-17T15:21:19.143Z',
+        type: 'session.start',
+      });
+
+      const parsed = parseJsonlLine(line);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.type).toBe('system');
+      expect(parsed?.content).toContain('Session started');
+    });
+
+    it('should parse unknown event types with content via fallback', () => {
+      const line = JSON.stringify({
+        data: { content: 'Design a database schema' },
+        id: 'ev-unknown',
+        timestamp: '2026-01-17T15:22:00.000Z',
+        type: 'user.request',
+      });
+
+      const parsed = parseJsonlLine(line);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.type).toBe('user');
+      expect(parsed?.content).toBe('Design a database schema');
+    });
+
+    it('should parse agent.* event types as assistant messages', () => {
+      const line = JSON.stringify({
+        data: { content: 'Analyzing your codebase...' },
+        id: 'ev-agent',
+        timestamp: '2026-01-17T15:22:00.000Z',
+        type: 'agent.response',
+      });
+
+      const parsed = parseJsonlLine(line);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.type).toBe('assistant');
+    });
+  });});

--- a/test/main/utils/pathDecoder.test.ts
+++ b/test/main/utils/pathDecoder.test.ts
@@ -11,6 +11,7 @@ import {
   extractSessionId,
   getProjectsBasePath,
   getTodosBasePath,
+  isSessionFileName,
   isValidEncodedPath,
 } from '../../../src/main/utils/pathDecoder';
 
@@ -114,6 +115,10 @@ describe('pathDecoder', () => {
     it('should fall back to decoded name when cwdHint is undefined', () => {
       expect(extractProjectName('-Users-username-projectname')).toBe('projectname');
     });
+
+    it('should return basename for non-encoded project IDs', () => {
+      expect(extractProjectName('workspace-123')).toBe('workspace-123');
+    });
   });
 
   describe('isValidEncodedPath', () => {
@@ -176,6 +181,24 @@ describe('pathDecoder', () => {
 
     it('should handle empty string', () => {
       expect(extractSessionId('')).toBe('');
+    });
+
+    it('should extract session ID from JSON filename', () => {
+      expect(extractSessionId('copilot-session.json')).toBe('copilot-session');
+    });
+  });
+
+  describe('isSessionFileName', () => {
+    it('should detect jsonl session files', () => {
+      expect(isSessionFileName('session-1.jsonl')).toBe(true);
+    });
+
+    it('should detect json session files', () => {
+      expect(isSessionFileName('session-1.json')).toBe(true);
+    });
+
+    it('should reject non-session files', () => {
+      expect(isSessionFileName('readme.md')).toBe(false);
     });
   });
 


### PR DESCRIPTION
This pull request adds support for discovering and managing Copilot session-state directories alongside existing Claude session/project data. The main changes introduce new IPC handlers, update service initialization to handle Copilot session paths, and enhance the project scanning logic to detect Copilot sessions in both legacy and current layouts.

<img width="450" height="285" alt="image" src="https://github.com/user-attachments/assets/38865b59-e370-4889-bc6b-dac9ee025bf8" />



