### PR TITLE
feat(package): add afterInstall script for chrome-sandbox permissions…

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,8 @@
         "pacman"
       ],
       "icon": "resources/icons/png",
-      "category": "Development"
+      "category": "Development",
+      "afterInstall": "resources/afterInstall.sh"
     },
     "nsis": {
       "oneClick": false,

--- a/resources/afterInstall.sh
+++ b/resources/afterInstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Fix chrome-sandbox permissions for SUID sandbox on Linux
+# See: https://github.com/electron/electron/issues/17972
+
+SANDBOX_PATH="/opt/${productFilename}/chrome-sandbox"
+
+if [ -f "$SANDBOX_PATH" ]; then
+  chown root:root "$SANDBOX_PATH"
+  chmod 4755 "$SANDBOX_PATH"
+fi


### PR DESCRIPTION
… (#27)

- Updated package.json to include an afterInstall script that adjusts permissions for the chrome-sandbox on Linux.
- Added new afterInstall.sh script to ensure proper ownership and permissions for the sandbox file, enhancing security and functionality.

Closes #26 