### PR TITLE
fix: increase macOS traffic light content gap for better title spacing

### DIFF
--- a/src/shared/constants/trafficLights.ts
+++ b/src/shared/constants/trafficLights.ts
@@ -22,7 +22,7 @@ const MACOS_TRAFFIC_LIGHT_GROUP_HEIGHT = 16;
 const MACOS_TRAFFIC_LIGHT_GROUP_WIDTH = 52;
 
 /** Visual gap between traffic lights and first left-aligned content */
-const MACOS_TRAFFIC_LIGHT_CONTENT_GAP = 8;
+const MACOS_TRAFFIC_LIGHT_CONTENT_GAP = 16;
 
 const MIN_ZOOM_FACTOR = 0.25;
 


### PR DESCRIPTION
## Summary

- Fixes insufficient horizontal spacing between macOS traffic lights and the project title in the sidebar
- `MACOS_TRAFFIC_LIGHT_CONTENT_GAP` was 8px, which is too tight compared to native macOS apps (Finder, Safari use 12-16px)
- Increased the gap from 8px to 16px, changing the total padding at 100% zoom from 72px to 80px
- The value propagates automatically to `SidebarHeader` and `TabBar` via the `--macos-traffic-light-padding-left` CSS variable

Closes #47