### PR TITLE
feat: color badges for subagent types with .claude/agents/ config support

### DIFF
--- a/src/main/http/utility.ts
+++ b/src/main/http/utility.ts
@@ -14,7 +14,7 @@ import { createLogger } from '@shared/utils/logger';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { type ClaudeMdFileInfo, readAllClaudeMdFiles, readDirectoryClaudeMd } from '../services';
+import { type ClaudeMdFileInfo, readAgentConfigs, readAllClaudeMdFiles, readDirectoryClaudeMd } from '../services';
 import { validateFilePath } from '../utils/pathValidation';
 import { countTokens } from '../utils/tokenizer';
 
@@ -122,5 +122,16 @@ export function registerUtilityRoutes(app: FastifyInstance): void {
   // Open external - no-op in browser mode
   app.post<{ Body: { url: string } }>('/api/open-external', async () => {
     return { success: false, error: 'Not available in browser mode' };
+  });
+
+  // Read agent configs
+  app.post<{ Body: { projectRoot: string } }>('/api/read-agent-configs', async (request) => {
+    try {
+      const { projectRoot } = request.body;
+      return await readAgentConfigs(projectRoot);
+    } catch (error) {
+      logger.error('Error in POST /api/read-agent-configs:', error);
+      return {};
+    }
   });
 }

--- a/src/main/ipc/utility.ts
+++ b/src/main/ipc/utility.ts
@@ -12,7 +12,9 @@ import { createLogger } from '@shared/utils/logger';
 import { app, type IpcMain, type IpcMainInvokeEvent, shell } from 'electron';
 import * as fs from 'fs';
 
-import { type ClaudeMdFileInfo, readAllClaudeMdFiles, readDirectoryClaudeMd } from '../services';
+import { type ClaudeMdFileInfo, readAgentConfigs, readAllClaudeMdFiles, readDirectoryClaudeMd } from '../services';
+
+import type { AgentConfig } from '@shared/types/api';
 
 const logger = createLogger('IPC:utility');
 import { validateFilePath, validateOpenPath } from '../utils/pathValidation';
@@ -28,6 +30,7 @@ export function registerUtilityHandlers(ipcMain: IpcMain): void {
   ipcMain.handle('read-claude-md-files', handleReadClaudeMdFiles);
   ipcMain.handle('read-directory-claude-md', handleReadDirectoryClaudeMd);
   ipcMain.handle('read-mentioned-file', handleReadMentionedFile);
+  ipcMain.handle('read-agent-configs', handleReadAgentConfigs);
 
   logger.info('Utility handlers registered');
 }
@@ -42,6 +45,7 @@ export function removeUtilityHandlers(ipcMain: IpcMain): void {
   ipcMain.removeHandler('read-claude-md-files');
   ipcMain.removeHandler('read-directory-claude-md');
   ipcMain.removeHandler('read-mentioned-file');
+  ipcMain.removeHandler('read-agent-configs');
 
   logger.info('Utility handlers removed');
 }
@@ -226,5 +230,21 @@ async function handleReadMentionedFile(
   } catch (error) {
     logger.error(`Error in read-mentioned-file for ${absolutePath}:`, error);
     return null;
+  }
+}
+
+/**
+ * Handler for 'read-agent-configs' IPC call.
+ * Reads agent definitions from project's .claude/agents/ directory.
+ */
+async function handleReadAgentConfigs(
+  _event: IpcMainInvokeEvent,
+  projectRoot: string
+): Promise<Record<string, AgentConfig>> {
+  try {
+    return await readAgentConfigs(projectRoot);
+  } catch (error) {
+    logger.error('Error in read-agent-configs:', error);
+    return {};
   }
 }

--- a/src/main/services/parsing/AgentConfigReader.ts
+++ b/src/main/services/parsing/AgentConfigReader.ts
@@ -1,0 +1,75 @@
+/**
+ * Agent Config Reader
+ *
+ * Reads `.claude/agents/*.md` files from a project directory and extracts
+ * frontmatter metadata (name, color) for use in subagent visualization.
+ */
+
+import { createLogger } from '@shared/utils/logger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { AgentConfig } from '@shared/types/api';
+
+const logger = createLogger('AgentConfigReader');
+
+/**
+ * Parse simple YAML frontmatter from markdown content.
+ * Only extracts top-level scalar key: value pairs between --- delimiters.
+ */
+function parseFrontmatter(content: string): Record<string, string> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  if (!match) return {};
+
+  const result: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = line.slice(colonIdx + 1).trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Read agent config files from a project's `.claude/agents/` directory.
+ * Returns a map of agent name → config (with optional color).
+ */
+export async function readAgentConfigs(
+  projectRoot: string
+): Promise<Record<string, AgentConfig>> {
+  const agentsDir = path.join(projectRoot, '.claude', 'agents');
+  const result: Record<string, AgentConfig> = {};
+
+  try {
+    const entries = await fs.promises.readdir(agentsDir);
+    const mdFiles = entries.filter((f) => f.endsWith('.md'));
+
+    await Promise.all(
+      mdFiles.map(async (filename) => {
+        try {
+          const content = await fs.promises.readFile(path.join(agentsDir, filename), 'utf8');
+          const frontmatter = parseFrontmatter(content);
+          const name = frontmatter.name || filename.replace(/\.md$/, '');
+          const config: AgentConfig = { name };
+          if (frontmatter.color) {
+            config.color = frontmatter.color;
+          }
+          result[name] = config;
+        } catch {
+          // Skip unreadable files
+        }
+      })
+    );
+  } catch {
+    // Directory doesn't exist or unreadable — normal for projects without custom agents
+    logger.debug(`No agents directory at ${agentsDir}`);
+  }
+
+  return result;
+}

--- a/src/main/services/parsing/index.ts
+++ b/src/main/services/parsing/index.ts
@@ -8,6 +8,7 @@
  * - GitIdentityResolver: Resolves git identities from sessions
  */
 
+export * from './AgentConfigReader';
 export * from './ClaudeMdReader';
 export * from './GitIdentityResolver';
 export * from './MessageClassifier';

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -169,6 +169,10 @@ const electronAPI: ElectronAPI = {
   readMentionedFile: (absolutePath: string, projectRoot: string, maxTokens?: number) =>
     ipcRenderer.invoke('read-mentioned-file', absolutePath, projectRoot, maxTokens),
 
+  // Agent config reading
+  readAgentConfigs: (projectRoot: string) =>
+    ipcRenderer.invoke('read-agent-configs', projectRoot),
+
   // Notifications API
   notifications: {
     get: (options?: { limit?: number; offset?: number }) =>

--- a/src/renderer/api/httpClient.ts
+++ b/src/renderer/api/httpClient.ts
@@ -41,6 +41,7 @@ import type {
   WaterfallData,
   WslClaudeRootCandidate,
 } from '@shared/types';
+import type { AgentConfig } from '@shared/types/api';
 
 export class HttpAPIClient implements ElectronAPI {
   private baseUrl: string;
@@ -308,6 +309,13 @@ export class HttpAPIClient implements ElectronAPI {
       projectRoot,
       maxTokens,
     });
+
+  // ---------------------------------------------------------------------------
+  // Agent config reading
+  // ---------------------------------------------------------------------------
+
+  readAgentConfigs = (projectRoot: string): Promise<Record<string, AgentConfig>> =>
+    this.post<Record<string, AgentConfig>>('/api/read-agent-configs', { projectRoot });
 
   // ---------------------------------------------------------------------------
   // Notifications (nested API)

--- a/src/renderer/constants/teamColors.ts
+++ b/src/renderer/constants/teamColors.ts
@@ -31,6 +31,30 @@ const DEFAULT_COLOR: TeamColorSet = TEAMMATE_COLORS.blue;
  * Get a TeamColorSet from a color name or hex string.
  * Falls back to blue if unrecognized.
  */
+const COLOR_NAMES = Object.keys(TEAMMATE_COLORS);
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+export function getSubagentTypeColorSet(
+  subagentType: string,
+  agentConfigs?: Record<string, { color?: string }>
+): TeamColorSet {
+  // Use color from agent config if available
+  const configColor = agentConfigs?.[subagentType]?.color;
+  if (configColor) {
+    return getTeamColorSet(configColor);
+  }
+  // Fallback: deterministic hash-based color
+  const index = hashString(subagentType) % COLOR_NAMES.length;
+  return TEAMMATE_COLORS[COLOR_NAMES[index]];
+}
+
 export function getTeamColorSet(colorName: string): TeamColorSet {
   if (!colorName) return DEFAULT_COLOR;
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -30,6 +30,15 @@ import type {
 } from '@main/types';
 
 // =============================================================================
+// Agent Config
+// =============================================================================
+
+export interface AgentConfig {
+  name: string;
+  color?: string;
+}
+
+// =============================================================================
 // Notifications API
 // =============================================================================
 
@@ -365,6 +374,9 @@ export interface ElectronAPI {
     projectRoot: string,
     maxTokens?: number
   ) => Promise<ClaudeMdFileInfo | null>;
+
+  // Agent config reading
+  readAgentConfigs: (projectRoot: string) => Promise<Record<string, AgentConfig>>;
 
   // Notifications API
   notifications: NotificationsAPI;

--- a/test/main/services/parsing/AgentConfigReader.test.ts
+++ b/test/main/services/parsing/AgentConfigReader.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { readAgentConfigs } from '@main/services/parsing/AgentConfigReader';
+
+describe('readAgentConfigs', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-config-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeAgent(filename: string, content: string): void {
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, filename), content);
+  }
+
+  it('returns empty object when .claude/agents/ does not exist', async () => {
+    const result = await readAgentConfigs(tmpDir);
+    expect(result).toEqual({});
+  });
+
+  it('parses agent with name and color from frontmatter', async () => {
+    writeAgent('test-agent.md', `---
+name: test-agent
+color: red
+---
+# Test agent
+`);
+    const result = await readAgentConfigs(tmpDir);
+    expect(result).toEqual({
+      'test-agent': { name: 'test-agent', color: 'red' },
+    });
+  });
+
+  it('uses filename as name when frontmatter has no name field', async () => {
+    writeAgent('my-agent.md', `---
+color: blue
+---
+# My Agent
+`);
+    const result = await readAgentConfigs(tmpDir);
+    expect(result['my-agent']).toBeDefined();
+    expect(result['my-agent'].color).toBe('blue');
+  });
+
+  it('handles agents without color field', async () => {
+    writeAgent('plain.md', `---
+name: plain
+description: "A plain agent"
+---
+Content
+`);
+    const result = await readAgentConfigs(tmpDir);
+    expect(result.plain).toEqual({ name: 'plain' });
+    expect(result.plain.color).toBeUndefined();
+  });
+
+  it('handles agents without frontmatter', async () => {
+    writeAgent('no-front.md', '# Just markdown\nNo frontmatter here.');
+    const result = await readAgentConfigs(tmpDir);
+    expect(result['no-front']).toEqual({ name: 'no-front' });
+  });
+
+  it('reads multiple agents', async () => {
+    writeAgent('a.md', `---\nname: a\ncolor: green\n---\n`);
+    writeAgent('b.md', `---\nname: b\ncolor: purple\n---\n`);
+    const result = await readAgentConfigs(tmpDir);
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.a.color).toBe('green');
+    expect(result.b.color).toBe('purple');
+  });
+
+  it('strips quotes from frontmatter values', async () => {
+    writeAgent('quoted.md', `---\nname: "quoted-agent"\ncolor: 'cyan'\n---\n`);
+    const result = await readAgentConfigs(tmpDir);
+    expect(result['quoted-agent']).toEqual({ name: 'quoted-agent', color: 'cyan' });
+  });
+
+  it('ignores non-md files', async () => {
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, 'readme.txt'), 'not an agent');
+    writeAgent('real.md', `---\nname: real\ncolor: red\n---\n`);
+    const result = await readAgentConfigs(tmpDir);
+    expect(Object.keys(result)).toEqual(['real']);
+  });
+});

--- a/test/renderer/constants/teamColors.test.ts
+++ b/test/renderer/constants/teamColors.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSubagentTypeColorSet, getTeamColorSet, TeamColorSet } from '@renderer/constants/teamColors';
+
+function isValidColorSet(cs: TeamColorSet): boolean {
+  return typeof cs.border === 'string' && typeof cs.badge === 'string' && typeof cs.text === 'string';
+}
+
+// =============================================================================
+// getTeamColorSet
+// =============================================================================
+
+describe('getTeamColorSet', () => {
+  it('returns blue (default) for empty string', () => {
+    const result = getTeamColorSet('');
+    expect(result.border).toBe('#3b82f6');
+  });
+
+  it('resolves named colors', () => {
+    expect(getTeamColorSet('green').border).toBe('#22c55e');
+    expect(getTeamColorSet('red').border).toBe('#ef4444');
+    expect(getTeamColorSet('purple').border).toBe('#a855f7');
+  });
+
+  it('is case-insensitive for named colors', () => {
+    expect(getTeamColorSet('Green')).toEqual(getTeamColorSet('green'));
+    expect(getTeamColorSet('BLUE')).toEqual(getTeamColorSet('blue'));
+  });
+
+  it('generates a color set from hex strings', () => {
+    const result = getTeamColorSet('#ff5500');
+    expect(result.border).toBe('#ff5500');
+    expect(result.badge).toBe('#ff550026');
+    expect(result.text).toBe('#ff5500');
+  });
+
+  it('falls back to blue for unknown non-hex strings', () => {
+    const result = getTeamColorSet('nonexistent');
+    expect(result.border).toBe('#3b82f6');
+  });
+});
+
+// =============================================================================
+// getSubagentTypeColorSet
+// =============================================================================
+
+describe('getSubagentTypeColorSet', () => {
+  it('always returns a valid TeamColorSet without agent configs', () => {
+    const types = ['test-agent', 'quality-fixer', 'Explore', 'Plan', 'my-custom-agent', 'anything'];
+    for (const t of types) {
+      const result = getSubagentTypeColorSet(t);
+      expect(isValidColorSet(result)).toBe(true);
+    }
+  });
+
+  it('is deterministic — same input always returns same color', () => {
+    const a = getSubagentTypeColorSet('my-custom-agent');
+    const b = getSubagentTypeColorSet('my-custom-agent');
+    expect(a).toEqual(b);
+  });
+
+  it('different types can produce different colors', () => {
+    const results = new Set(
+      ['Explore', 'Plan', 'test-agent', 'quality-fixer', 'claude-md-auditor', 'Bash', 'general-purpose', 'statusline-setup']
+        .map((t) => getSubagentTypeColorSet(t).border)
+    );
+    expect(results.size).toBeGreaterThan(1);
+  });
+
+  it('uses color from agent config when available', () => {
+    const configs = {
+      'test-agent': { name: 'test-agent', color: 'red' },
+    };
+    const result = getSubagentTypeColorSet('test-agent', configs);
+    // Should use the named "red" color from getTeamColorSet
+    expect(result.border).toBe('#ef4444');
+    expect(result.text).toBe('#f87171');
+  });
+
+  it('uses hex color from agent config', () => {
+    const configs = {
+      'my-agent': { name: 'my-agent', color: '#ff00ff' },
+    };
+    const result = getSubagentTypeColorSet('my-agent', configs);
+    expect(result.border).toBe('#ff00ff');
+  });
+
+  it('falls back to hash when agent config has no color', () => {
+    const configs = {
+      'my-agent': { name: 'my-agent' },
+    };
+    const withConfig = getSubagentTypeColorSet('my-agent', configs);
+    const withoutConfig = getSubagentTypeColorSet('my-agent');
+    // Should be the same — both use hash fallback
+    expect(withConfig).toEqual(withoutConfig);
+  });
+
+  it('falls back to hash when agent type not in configs', () => {
+    const configs = {
+      'other-agent': { name: 'other-agent', color: 'green' },
+    };
+    const withConfig = getSubagentTypeColorSet('unknown-agent', configs);
+    const withoutConfig = getSubagentTypeColorSet('unknown-agent');
+    expect(withConfig).toEqual(withoutConfig);
+  });
+
+  it('does not interfere with getTeamColorSet', () => {
+    const teamGreen = getTeamColorSet('green');
+    expect(teamGreen.border).toBe('#22c55e');
+
+    const configs = { green: { name: 'green', color: 'purple' } };
+    getSubagentTypeColorSet('green', configs);
+    // Team API remains unaffected
+    expect(getTeamColorSet('green').border).toBe('#22c55e');
+  });
+});


### PR DESCRIPTION
## Summary

- Subagent badges now display distinct colors instead of generic gray, making different agent types visually distinguishable at a glance
- Colors are resolved from the project's `.claude/agents/*.md` frontmatter (`color` field), matching the user's configured color for each agent
- When no agent config exists, colors are generated deterministically via a string hash — any custom agent type gets a consistent color automatically
- New **AgentConfigReader** service reads and parses agent definitions from `.claude/agents/` via IPC. Results are cached per `projectRoot`, so session refreshes (file watcher turns) don't re-read from disk
- Team member colors (Orchestrate Teams) are unaffected — team branch always takes priority

### Future extensibility

The `AgentConfigReader` already parses the full frontmatter of agent files. Today it exposes `name` and `color`, but it can be extended to surface other [supported frontmatter fields](https://code.claude.com/docs/en/sub-agents#supported-frontmatter-fields) like `description`, `model`, `tools` — enabling richer agent tooltips, model badges, or tool inventory views.

### Screenshots

| CLI | claude-devtools |
|-----------|----------|
| ![CLI](https://github.com/user-attachments/assets/da33506b-a612-4d91-8040-d50cf3c0a971) | ![claude-devtools](https://github.com/user-attachments/assets/86d6b414-3efc-411b-aa7d-43154c14109c) |

## Testing

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes