### PR TITLE
fix: auto-expand sidebar when a project is selected

### DIFF
--- a/src/renderer/store/slices/projectSlice.ts
+++ b/src/renderer/store/slices/projectSlice.ts
@@ -59,6 +59,7 @@ export const createProjectSlice: StateCreator<AppState, [], [], ProjectSlice> = 
   selectProject: (id: string) => {
     set({
       selectedProjectId: id,
+      sidebarCollapsed: false, // Ensure session list is visible when a project is selected
       ...getSessionResetState(),
     });
 

--- a/src/renderer/store/slices/repositorySlice.ts
+++ b/src/renderer/store/slices/repositorySlice.ts
@@ -87,6 +87,7 @@ export const createRepositorySlice: StateCreator<AppState, [], [], RepositorySli
         selectedWorktreeId: worktreeToSelect.id,
         selectedProjectId: worktreeToSelect.id,
         activeProjectId: worktreeToSelect.id,
+        sidebarCollapsed: false, // Ensure session list is visible when a project is selected
         ...getSessionResetState(),
       });
       // Fetch sessions for this worktree


### PR DESCRIPTION
## Summary

When the sidebar is collapsed and the user clicks a project, the session list updated silently behind the hidden panel — no visual feedback, nothing appeared to happen. The user had to manually re-open the sidebar to see the result.

Selecting a project implies intent to browse its sessions. The sidebar should open automatically to reflect that.

## Root Cause

Project selection is handled in two separate store actions:
- `selectRepository` — triggered by dashboard project cards
- `selectProject` — triggered by the command palette and keyboard shortcuts

Neither action accounted for the sidebar being collapsed when called.

## Fix

Added `sidebarCollapsed: false` to the `set()` call in both `selectProject` and `selectRepository`. The change is atomic with the selection itself — the sidebar opens at exactly the same moment the session list updates.

```ts
// selectProject (projectSlice.ts)
set({
  selectedProjectId: id,
  sidebarCollapsed: false, // Ensure session list is visible when a project is selected
  ...getSessionResetState(),
});

// selectRepository (repositorySlice.ts)
set({
  selectedRepositoryId: repositoryId,
  selectedWorktreeId: worktreeToSelect.id,
  selectedProjectId: worktreeToSelect.id,
  activeProjectId: worktreeToSelect.id,
  sidebarCollapsed: false, // Ensure session list is visible when a project is selected
  ...getSessionResetState(),
});
```

## Files Changed

| File | Change |
|------|--------|
| `src/renderer/store/slices/projectSlice.ts` | Uncollapse sidebar on `selectProject` |
| `src/renderer/store/slices/repositorySlice.ts` | Uncollapse sidebar on `selectRepository` |

## Test Plan

- [ ] Collapse the sidebar (Cmd+B or the toggle button)
- [ ] Click any project from the dashboard — sidebar should open automatically
- [ ] Open the command palette (Cmd+K), select a project — sidebar should open automatically
- [ ] Selecting a session within an already-open sidebar is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)