### PR TITLE
fix: wrap HTTP_SERVER_GET_STATUS response in IpcResult envelope

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -310,7 +310,7 @@ function initializeServices(): void {
   });
 
   ipcMain.handle(HTTP_SERVER_GET_STATUS, () => {
-    return { running: httpServer.isRunning(), port: httpServer.getPort() };
+    return { success: true, data: { running: httpServer.isRunning(), port: httpServer.getPort() } };
   });
 
   // Forward SSH state changes to renderer and HTTP SSE clients


### PR DESCRIPTION
## Summary

Opening the Settings page threw an unhandled promise rejection every time:

```
Uncaught (in promise) Error: Unknown error
```

## Root Cause

The three HTTP server IPC handlers are inconsistent in how they return data:

| Handler | Response shape |
|---|---|
| `HTTP_SERVER_START` | `{ success: true, data: { running, port } }` ✅ |
| `HTTP_SERVER_STOP` | `{ success: true, data: { running, port } }` ✅ |
| `HTTP_SERVER_GET_STATUS` | `{ running, port }` ❌ |

`invokeIpcWithResult()` in the preload layer expects every handler to return an `IpcResult<T>` envelope (`{ success, data }`). When `success` is absent it's falsy, so the function throws:

```ts
if (!result.success) {
  throw new Error(result.error ?? 'Unknown error'); // result.error also undefined → "Unknown error"
}
```

`GeneralSection` calls `api.httpServer.getStatus()` on mount, so the error fired immediately every time Settings opened.

## Fix

Wrap the `HTTP_SERVER_GET_STATUS` return value in the standard `IpcResult` envelope, matching the other two handlers.

```ts
// Before
ipcMain.handle(HTTP_SERVER_GET_STATUS, () => {
  return { running: httpServer.isRunning(), port: httpServer.getPort() };
});

// After
ipcMain.handle(HTTP_SERVER_GET_STATUS, () => {
  return { success: true, data: { running: httpServer.isRunning(), port: httpServer.getPort() } };
});
```

## Files Changed

| File | Change |
|---|---|
| `src/main/index.ts` | Wrap `HTTP_SERVER_GET_STATUS` response in `IpcResult` envelope |

## Test Plan

- [ ] Open Settings — no `Unknown error` in the DevTools console
- [ ] HTTP server toggle in Settings still starts/stops correctly
- [ ] Server status indicator reflects current state on Settings open

🤖 Generated with [Claude Code](https://claude.com/claude-code)