### PR TITLE
feat: add auto-expand AI response groups setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 ## [Unreleased]
 
 ### Added
+- `general.autoExpandAIGroups` setting: automatically expands all AI response groups when opening a transcript or when new AI responses arrive in a live session. Defaults to off. Stored in the on-disk config so it persists across restarts.
+
+
 - Strict IPC input validation guards for project/session/subagent/search limits.
 - `get-waterfall-data` IPC endpoint implementation.
 - Cross-platform path normalization in renderer path resolvers.

--- a/src/main/ipc/configValidation.ts
+++ b/src/main/ipc/configValidation.ts
@@ -203,6 +203,7 @@ function validateGeneralSection(data: unknown): ValidationSuccess<'general'> | V
     'theme',
     'defaultTab',
     'claudeRootPath',
+    'autoExpandAIGroups',
   ];
 
   const result: Partial<GeneralConfig> = {};
@@ -266,6 +267,12 @@ function validateGeneralSection(data: unknown): ValidationSuccess<'general'> | V
           }
           result.claudeRootPath = path.resolve(normalized);
         }
+        break;
+      case 'autoExpandAIGroups':
+        if (typeof value !== 'boolean') {
+          return { valid: false, error: `general.${key} must be a boolean` };
+        }
+        result.autoExpandAIGroups = value;
         break;
       default:
         return { valid: false, error: `Unsupported general key: ${key}` };

--- a/src/main/services/infrastructure/ConfigManager.ts
+++ b/src/main/services/infrastructure/ConfigManager.ts
@@ -181,6 +181,7 @@ export interface GeneralConfig {
   theme: 'dark' | 'light' | 'system';
   defaultTab: 'dashboard' | 'last-session';
   claudeRootPath: string | null;
+  autoExpandAIGroups: boolean;
 }
 
 export interface DisplayConfig {
@@ -248,6 +249,7 @@ const DEFAULT_CONFIG: AppConfig = {
     theme: 'dark',
     defaultTab: 'dashboard',
     claudeRootPath: null,
+    autoExpandAIGroups: false,
   },
   display: {
     showTimestamps: true,

--- a/src/renderer/components/settings/hooks/useSettingsConfig.ts
+++ b/src/renderer/components/settings/hooks/useSettingsConfig.ts
@@ -30,6 +30,7 @@ export interface SafeConfig {
     theme: 'dark' | 'light' | 'system';
     defaultTab: 'dashboard' | 'last-session';
     claudeRootPath: string | null;
+    autoExpandAIGroups: boolean;
   };
   notifications: {
     enabled: boolean;
@@ -154,6 +155,7 @@ export function useSettingsConfig(): UseSettingsConfigReturn {
         theme: displayConfig?.general?.theme ?? 'dark',
         defaultTab: displayConfig?.general?.defaultTab ?? 'dashboard',
         claudeRootPath: displayConfig?.general?.claudeRootPath ?? null,
+        autoExpandAIGroups: displayConfig?.general?.autoExpandAIGroups ?? false,
       },
       notifications: {
         enabled: displayConfig?.notifications?.enabled ?? true,

--- a/src/renderer/components/settings/hooks/useSettingsHandlers.ts
+++ b/src/renderer/components/settings/hooks/useSettingsHandlers.ts
@@ -287,6 +287,7 @@ export function useSettingsHandlers({
           theme: 'dark',
           defaultTab: 'dashboard',
           claudeRootPath: null,
+          autoExpandAIGroups: false,
         },
         display: {
           showTimestamps: true,

--- a/src/renderer/components/settings/sections/GeneralSection.tsx
+++ b/src/renderer/components/settings/sections/GeneralSection.tsx
@@ -15,6 +15,7 @@ import { SettingRow, SettingsSectionHeader, SettingsSelect, SettingsToggle } fro
 import type { SafeConfig } from '../hooks/useSettingsConfig';
 import type { ClaudeRootInfo, WslClaudeRootCandidate } from '@shared/types';
 import type { HttpServerStatus } from '@shared/types/api';
+import type { AppConfig } from '@shared/types/notifications';
 
 // Theme options
 const THEME_OPTIONS = [
@@ -26,7 +27,7 @@ const THEME_OPTIONS = [
 interface GeneralSectionProps {
   readonly safeConfig: SafeConfig;
   readonly saving: boolean;
-  readonly onGeneralToggle: (key: 'launchAtLogin' | 'showDockIcon', value: boolean) => void;
+  readonly onGeneralToggle: (key: keyof AppConfig['general'], value: boolean) => void;
   readonly onThemeChange: (value: 'dark' | 'light' | 'system') => void;
 }
 
@@ -283,6 +284,16 @@ export const GeneralSection = ({
           value={safeConfig.general.theme}
           options={THEME_OPTIONS}
           onChange={onThemeChange}
+          disabled={saving}
+        />
+      </SettingRow>
+      <SettingRow
+        label="Expand AI responses by default"
+        description="Automatically expand each response turn when opening a transcript or receiving a new message"
+      >
+        <SettingsToggle
+          enabled={safeConfig.general.autoExpandAIGroups ?? false}
+          onChange={(v) => onGeneralToggle('autoExpandAIGroups', v)}
           disabled={saving}
         />
       </SettingRow>

--- a/src/renderer/store/slices/sessionDetailSlice.ts
+++ b/src/renderer/store/slices/sessionDetailSlice.ts
@@ -416,6 +416,15 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
         sessionPhaseInfo: phaseInfo,
       });
 
+      // Auto-expand all AI groups if the setting is enabled
+      if (tabId && conversation?.items && get().appConfig?.general?.autoExpandAIGroups) {
+        for (const item of conversation.items) {
+          if (item.type === 'ai') {
+            get().expandAIGroupForTab(tabId, item.group.id);
+          }
+        }
+      }
+
       // Store per-tab session data
       if (tabId) {
         const prev = get().tabSessionData;
@@ -554,6 +563,14 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
         }
       }
 
+      // Snapshot existing AI group IDs before overwriting state, so the
+      // auto-expand diff below can correctly identify which groups are new.
+      const prevGroupIds = new Set(
+        (latestState.conversation?.items ?? [])
+          .filter((item) => item.type === 'ai')
+          .map((item) => (item as { type: 'ai'; group: { id: string } }).group.id)
+      );
+
       // Update only the data, preserve UI states
       set((state) => ({
         sessionDetail: detail,
@@ -571,6 +588,29 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
         // Note: aiGroupExpansionLevels and expandedStepIds are NOT touched
         // so expansion states are preserved
       }));
+
+      // Auto-expand newly arrived AI groups if the setting is enabled.
+      // Uses prevGroupIds snapshotted before set() so the diff is accurate.
+      if (get().appConfig?.general?.autoExpandAIGroups) {
+        const oldGroupIds = prevGroupIds;
+        const newGroupIds = newConversation.items
+          .filter(
+            (item) =>
+              item.type === 'ai' &&
+              !oldGroupIds.has((item as { type: 'ai'; group: { id: string } }).group.id)
+          )
+          .map((item) => (item as { type: 'ai'; group: { id: string } }).group.id);
+
+        if (newGroupIds.length > 0) {
+          for (const tab of latestAllTabs) {
+            if (tab.type === 'session' && tab.sessionId === sessionId) {
+              for (const groupId of newGroupIds) {
+                get().expandAIGroupForTab(tab.id, groupId);
+              }
+            }
+          }
+        }
+      }
 
       // Also update per-tab session data for all tabs viewing this session
       const latestTabSessionData = { ...get().tabSessionData };

--- a/src/shared/types/notifications.ts
+++ b/src/shared/types/notifications.ts
@@ -262,6 +262,8 @@ export interface AppConfig {
     defaultTab: 'dashboard' | 'last-session';
     /** Optional custom Claude root folder (auto-detected when null) */
     claudeRootPath: string | null;
+    /** Whether to auto-expand AI response groups when opening a transcript or receiving new messages */
+    autoExpandAIGroups: boolean;
   };
   /** Display and UI settings */
   display: {

--- a/test/main/ipc/configValidation.test.ts
+++ b/test/main/ipc/configValidation.test.ts
@@ -20,6 +20,28 @@ describe('configValidation', () => {
     }
   });
 
+  it('accepts general.autoExpandAIGroups boolean toggle', () => {
+    const resultOn = validateConfigUpdatePayload('general', { autoExpandAIGroups: true });
+    expect(resultOn.valid).toBe(true);
+    if (resultOn.valid) {
+      expect(resultOn.data).toEqual({ autoExpandAIGroups: true });
+    }
+
+    const resultOff = validateConfigUpdatePayload('general', { autoExpandAIGroups: false });
+    expect(resultOff.valid).toBe(true);
+    if (resultOff.valid) {
+      expect(resultOff.data).toEqual({ autoExpandAIGroups: false });
+    }
+  });
+
+  it('rejects non-boolean general.autoExpandAIGroups', () => {
+    const result = validateConfigUpdatePayload('general', { autoExpandAIGroups: 'yes' });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('boolean');
+    }
+  });
+
   it('accepts absolute general.claudeRootPath updates', () => {
     const result = validateConfigUpdatePayload('general', {
       claudeRootPath: '/Users/test/.claude',


### PR DESCRIPTION
## Summary

- Adds a persistent **Auto-expand AI responses** toggle in Settings → General (Appearance section)
- When enabled, all AI response drawers open automatically when loading a transcript — no more clicking each chevron individually
- Live sessions also auto-expand new AI groups as they arrive, preserving any groups the user manually collapsed earlier in the session
- Setting survives restarts and `/clear` because it lives in the on-disk config (`~/.claude/claude-devtools-config.json`)

## Changes

- `ConfigManager.ts` / `notifications.ts` — add `autoExpandAIGroups: boolean` to `GeneralConfig` in both the main-process and shared type definitions
- `configValidation.ts` — add `autoExpandAIGroups` to the IPC allowlist with boolean validation
- `sessionDetailSlice.ts` — expand all groups on initial load; expand only newly arrived groups on live refresh (bug fixed: snapshot of old group IDs was taken after `set()` overwrote state, causing the diff to always be empty)
- `GeneralSection.tsx` / `SafeConfig` / `useSettingsHandlers.ts` — wire up the toggle in Settings
- `test/main/ipc/configValidation.test.ts` — two new cases covering the happy path and non-boolean rejection
- `CHANGELOG.md` — entry under `[Unreleased] > Added`

## Test plan

- [ ] Enable the setting in Settings → General → Auto-expand AI responses
- [ ] Open any existing transcript — all AI drawers should be expanded immediately
- [ ] Send a new message in an active session — the new AI response drawer should expand automatically
- [ ] Manually collapse a drawer mid-session, then receive another response — only the new drawer expands, the collapsed one stays collapsed
- [ ] Disable the setting — drawers return to collapsed-by-default behavior
- [ ] Restart the app with the setting on — setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Expand AI responses by default" setting available in the General preferences section. When enabled, all AI response groups are automatically expanded upon opening session transcripts or when receiving new messages during live sessions. The preference persists across application restarts and is disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->