### PR TITLE
fix: guard Notification.isSupported for standalone/Docker (#42)

### DIFF
--- a/src/main/services/infrastructure/NotificationManager.ts
+++ b/src/main/services/infrastructure/NotificationManager.ts
@@ -373,8 +373,12 @@ export class NotificationManager extends EventEmitter {
    * Shows a native macOS notification for an error.
    */
   private showNativeNotification(error: DetectedError): void {
-    // Check if Notification is supported
-    if (!Notification.isSupported()) {
+    // Guard against standalone/Docker mode where Electron's Notification API is unavailable
+    if (
+      typeof Notification === 'undefined' ||
+      typeof Notification.isSupported !== 'function' ||
+      !Notification.isSupported()
+    ) {
       logger.warn('Native notifications not supported');
       return;
     }


### PR DESCRIPTION
## Summary
- Add typeof checks before calling Notification.isSupported() to prevent crashes in environments where the Notification API is unavailable

Fixes #42

## Changes
- src/main/services/infrastructure/NotificationManager.ts - Add typeof guards for Notification and Notification.isSupported

## Test plan
- [ ] App starts without crash in Docker/standalone mode
- [ ] Native notifications still work in normal Electron mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification system reliability by adding defensive checks for environments where the Notification API is unavailable (e.g., Docker, standalone deployments). The system now gracefully handles these scenarios with appropriate logging while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->