### PR TITLE
fix: deduplicate streaming JSONL entries to prevent ~2x cost overcounting

### DIFF
--- a/src/main/types/messages.ts
+++ b/src/main/types/messages.ts
@@ -103,6 +103,8 @@ export interface ParsedMessage {
   toolUseResult?: ToolUseResultData;
   /** Whether this is a compact summary boundary message */
   isCompactSummary?: boolean;
+  /** API request ID for deduplicating streaming entries */
+  requestId?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Claude Code writes multiple JSONL entries per API response during streaming, each with the same `requestId` but incrementally increasing `output_tokens`
- Our parser summed every entry independently, inflating costs by ~2x compared to Claude Code's `/cost` command
- Fix: keep only the **last entry per `requestId`** (the final, complete token counts) — same approach as [ryoppippi/ccusage#835](https://github.com/ryoppippi/ccusage/pull/835)

## Changes
| File | Change |
|------|--------|
| `src/main/types/messages.ts` | Add `requestId?: string` to `ParsedMessage` |
| `src/main/utils/jsonl.ts` | Extract `requestId` from `AssistantEntry`; add `deduplicateByRequestId()`; apply dedup in `calculateMetrics()` |
| `src/renderer/utils/sessionAnalyzer.ts` | Skip duplicate streaming entries in cost accounting loop |
| `test/main/utils/costCalculation.test.ts` | 6 new test cases for streaming dedup |

## How it works
- `deduplicateByRequestId()` scans messages to find the last index per `requestId`, then filters out earlier duplicates
- Messages without `requestId` (user, system) pass through unchanged
- Applied in both `calculateMetrics()` (main process) and `sessionAnalyzer` (renderer)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint:fix` — 0 errors
- [x] `pnpm test` — 833 tests pass (6 new)
- [ ] Manual: compare session cost with Claude Code `/cost` output

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming deduplication to remove duplicate assistant entries and preserve only the final per-request message.
  * Introduced an optional per-request identifier on messages to enable that deduplication.

* **Improvements**
  * Metrics (token and cost) now compute from deduplicated streaming messages for more accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->