### PR TITLE
fix(#85): Ctrl+R session refresh via IPC with scroll-to-bottom

### DIFF
--- a/src/preload/constants/ipcChannels.ts
+++ b/src/preload/constants/ipcChannels.ts
@@ -174,3 +174,6 @@ export const WINDOW_IS_MAXIMIZED = 'window:isMaximized';
 
 /** Relaunch the application */
 export const APP_RELAUNCH = 'app:relaunch';
+
+/** Refresh session shortcut (main → renderer, triggered by Ctrl+R / Cmd+R) */
+export const SESSION_REFRESH = 'session:refresh';

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,7 @@ import {
   HTTP_SERVER_GET_STATUS,
   HTTP_SERVER_START,
   HTTP_SERVER_STOP,
+  SESSION_REFRESH,
   SSH_CONNECT,
   SSH_DISCONNECT,
   SSH_GET_CONFIG_HOSTS,
@@ -344,6 +345,15 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.on('file-change', listener);
     return (): void => {
       ipcRenderer.removeListener('file-change', listener);
+    };
+  },
+
+  // Session refresh event (Ctrl+R / Cmd+R intercepted by main process)
+  onSessionRefresh: (callback: () => void): (() => void) => {
+    const listener = (): void => callback();
+    ipcRenderer.on(SESSION_REFRESH, listener);
+    return (): void => {
+      ipcRenderer.removeListener(SESSION_REFRESH, listener);
     };
   },
 

--- a/src/renderer/api/httpClient.ts
+++ b/src/renderer/api/httpClient.ts
@@ -490,6 +490,11 @@ export class HttpAPIClient implements ElectronAPI {
   onTodoChange = (callback: (event: FileChangeEvent) => void): (() => void) =>
     this.addEventListener('todo-change', callback);
 
+  // No-op in browser mode — Ctrl+R refresh is Electron-only
+  onSessionRefresh = (_callback: () => void): (() => void) => {
+    return () => {};
+  };
+
   // ---------------------------------------------------------------------------
   // Shell operations (browser fallbacks)
   // ---------------------------------------------------------------------------

--- a/src/renderer/components/chat/ChatHistory.tsx
+++ b/src/renderer/components/chat/ChatHistory.tsx
@@ -377,6 +377,15 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
     checkScrollButton();
   }, [conversation, checkScrollButton]);
 
+  // Listen for session-refresh-scroll-bottom events (from Ctrl+R / refresh button)
+  useEffect(() => {
+    const handler = (): void => {
+      scrollToBottom('smooth');
+    };
+    window.addEventListener('session-refresh-scroll-bottom', handler);
+    return () => window.removeEventListener('session-refresh-scroll-bottom', handler);
+  }, [scrollToBottom]);
+
   // Callback to register AI group refs (combines with visibility hook)
   const registerAIGroupRefCombined = useCallback(
     (groupId: string) => {

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -39,7 +39,7 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
     setSelectedTabIds,
     clearTabSelection,
     openDashboard,
-    fetchSessionDetail,
+    refreshSessionInPlace,
     fetchSessions,
     unreadCount,
     openNotificationsTab,
@@ -64,7 +64,7 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
       setSelectedTabIds: s.setSelectedTabIds,
       clearTabSelection: s.clearTabSelection,
       openDashboard: s.openDashboard,
-      fetchSessionDetail: s.fetchSessionDetail,
+      refreshSessionInPlace: s.refreshSessionInPlace,
       fetchSessions: s.fetchSessions,
       unreadCount: s.unreadCount,
       openNotificationsTab: s.openNotificationsTab,
@@ -215,9 +215,10 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
   const handleRefresh = async (): Promise<void> => {
     if (activeTab?.type === 'session' && activeTab.projectId && activeTab.sessionId) {
       await Promise.all([
-        fetchSessionDetail(activeTab.projectId, activeTab.sessionId, activeTabId ?? undefined),
+        refreshSessionInPlace(activeTab.projectId, activeTab.sessionId),
         fetchSessions(activeTab.projectId),
       ]);
+      window.dispatchEvent(new CustomEvent('session-refresh-scroll-bottom'));
     }
   };
 

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -29,7 +29,7 @@ export function useKeyboardShortcuts(): void {
     getActiveTab,
     selectedProjectId,
     selectedSessionId,
-    fetchSessionDetail,
+    refreshSessionInPlace,
     fetchSessions,
     openCommandPalette,
     openSettingsTab,
@@ -56,7 +56,7 @@ export function useKeyboardShortcuts(): void {
       getActiveTab: s.getActiveTab,
       selectedProjectId: s.selectedProjectId,
       selectedSessionId: s.selectedSessionId,
-      fetchSessionDetail: s.fetchSessionDetail,
+      refreshSessionInPlace: s.refreshSessionInPlace,
       fetchSessions: s.fetchSessions,
       openCommandPalette: s.openCommandPalette,
       openSettingsTab: s.openSettingsTab,
@@ -261,9 +261,11 @@ export function useKeyboardShortcuts(): void {
         event.preventDefault();
         if (selectedProjectId && selectedSessionId) {
           void Promise.all([
-            fetchSessionDetail(selectedProjectId, selectedSessionId),
+            refreshSessionInPlace(selectedProjectId, selectedSessionId),
             fetchSessions(selectedProjectId),
-          ]);
+          ]).then(() => {
+            window.dispatchEvent(new CustomEvent('session-refresh-scroll-bottom'));
+          });
         }
         return;
       }
@@ -290,7 +292,7 @@ export function useKeyboardShortcuts(): void {
     getActiveTab,
     selectedProjectId,
     selectedSessionId,
-    fetchSessionDetail,
+    refreshSessionInPlace,
     fetchSessions,
     openCommandPalette,
     openSettingsTab,

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -395,6 +395,9 @@ export interface ElectronAPI {
   onFileChange: (callback: (event: FileChangeEvent) => void) => () => void;
   onTodoChange: (callback: (event: FileChangeEvent) => void) => () => void;
 
+  // Session refresh (Ctrl+R / Cmd+R intercepted by main process)
+  onSessionRefresh: (callback: () => void) => () => void;
+
   // Shell operations
   openPath: (
     targetPath: string,


### PR DESCRIPTION
## Summary
- Route Ctrl+R through IPC (main → preload → renderer) since `event.preventDefault()` in `before-input-event` blocks both Chromium reload and keydown propagation
- Switch all refresh paths (IPC listener, refresh button, keyboard shortcut fallback) to `refreshSessionInPlace` to avoid unmounting the scroll container
- Dispatch `session-refresh-scroll-bottom` custom event to smoothly scroll to bottom after refresh

Rebased onto latest main (after #87 revert) from a dedicated feature branch.

## Test plan
- [ ] Press Ctrl+R (or Cmd+R on macOS) — session refreshes and scrolls to bottom without flicker
- [ ] Click the refresh button in the tab bar — same behavior
- [ ] Ctrl+Shift+R is blocked (no hard reload)
- [ ] Non-Electron (browser) mode: no errors from missing `onSessionRefresh`

Fixes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a session refresh shortcut (Ctrl/Cmd+R) that updates your active session in-place without requiring a full page reload. The chat automatically scrolls to the bottom when refresh completes.
  * Hard reload functionality (Ctrl/Cmd+Shift+R) has been disabled to prevent unintended interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->