### PR TITLE
feat: multi-theme support, step variants, and content display improvements

### DIFF
--- a/src/main/ipc/configValidation.ts
+++ b/src/main/ipc/configValidation.ts
@@ -14,6 +14,13 @@ import type {
   NotificationTrigger,
   SshPersistConfig,
 } from '../services';
+import type { ThemeName } from '@shared/types/notifications';
+
+const VALID_THEMES: ThemeName[] = [
+  'dark', 'light', 'system',
+  'monokai', 'dracula', 'solarized-dark', 'solarized-light',
+  'nord', 'github-light', 'github-dark',
+];
 
 type ConfigSection = keyof AppConfig;
 
@@ -228,10 +235,10 @@ function validateGeneralSection(data: unknown): ValidationSuccess<'general'> | V
         result.showDockIcon = value;
         break;
       case 'theme':
-        if (value !== 'dark' && value !== 'light' && value !== 'system') {
-          return { valid: false, error: 'general.theme must be one of: dark, light, system' };
+        if (!VALID_THEMES.includes(value as ThemeName)) {
+          return { valid: false, error: `general.theme must be one of: ${VALID_THEMES.join(', ')}` };
         }
-        result.theme = value;
+        result.theme = value as ThemeName;
         break;
       case 'defaultTab':
         if (value !== 'dashboard' && value !== 'last-session') {

--- a/src/main/services/infrastructure/ConfigManager.ts
+++ b/src/main/services/infrastructure/ConfigManager.ts
@@ -20,6 +20,7 @@ import { DEFAULT_TRIGGERS, TriggerManager } from './TriggerManager';
 
 import type { TriggerColor } from '@shared/constants/triggerColors';
 import type { SshConnectionProfile } from '@shared/types/api';
+import type { ThemeName } from '@shared/types/notifications';
 
 const logger = createLogger('Service:ConfigManager');
 
@@ -178,7 +179,7 @@ export interface NotificationTrigger {
 export interface GeneralConfig {
   launchAtLogin: boolean;
   showDockIcon: boolean;
-  theme: 'dark' | 'light' | 'system';
+  theme: ThemeName;
   defaultTab: 'dashboard' | 'last-session';
   claudeRootPath: string | null;
   autoExpandAIGroups: boolean;

--- a/src/renderer/components/chat/DisplayItemList.tsx
+++ b/src/renderer/components/chat/DisplayItemList.tsx
@@ -96,7 +96,7 @@ export const DisplayItemList = ({
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {items.map((item, index) => {
         let itemKey = '';
         let element: React.ReactNode = null;

--- a/src/renderer/components/chat/items/BaseItem.tsx
+++ b/src/renderer/components/chat/items/BaseItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { TOOL_ITEM_MUTED } from '@renderer/constants/cssVariables';
+import { getStepVariantStyle, type StepVariant } from '@renderer/constants/stepVariants';
 import { getTriggerColorDef, type TriggerColor } from '@shared/constants/triggerColors';
 import { ChevronRight } from 'lucide-react';
 
@@ -39,6 +40,8 @@ interface BaseItemProps {
   highlightStyle?: React.CSSProperties;
   /** Notification dot color for custom triggers */
   notificationDotColor?: TriggerColor;
+  /** Step variant for color-coded borders and icons */
+  variant?: StepVariant;
   /** Children rendered when expanded */
   children?: React.ReactNode;
 }
@@ -86,8 +89,11 @@ export const BaseItem: React.FC<BaseItemProps> = ({
   highlightClasses = '',
   highlightStyle,
   notificationDotColor,
+  variant,
   children,
 }) => {
+  const variantStyle = variant ? getStepVariantStyle(variant) : undefined;
+
   return (
     <div
       className={`rounded transition-all duration-300 ${highlightClasses}`}
@@ -114,12 +120,12 @@ export const BaseItem: React.FC<BaseItemProps> = ({
         }
       >
         {/* Icon */}
-        <span className="size-4 shrink-0" style={{ color: TOOL_ITEM_MUTED }}>
+        <span className="size-4 shrink-0" style={{ color: variantStyle?.iconColor ?? TOOL_ITEM_MUTED }}>
           {icon}
         </span>
 
         {/* Label */}
-        <span className="text-sm font-medium" style={{ color: 'var(--tool-item-name)' }}>
+        <span className="text-[13px] font-medium" style={{ color: 'var(--tool-item-name)' }}>
           {label}
         </span>
 
@@ -181,8 +187,8 @@ export const BaseItem: React.FC<BaseItemProps> = ({
       {/* Expanded Content */}
       {isExpanded && children && (
         <div
-          className="ml-2 mt-2 space-y-3 pl-6"
-          style={{ borderLeft: '2px solid var(--color-border)' }}
+          className="animate-expand ml-2 mt-2 space-y-3 pl-6"
+          style={{ borderLeft: `2px solid ${variantStyle?.borderColor ?? 'var(--color-border)'}` }}
         >
           {children}
         </div>

--- a/src/renderer/components/chat/items/SlashItem.tsx
+++ b/src/renderer/components/chat/items/SlashItem.tsx
@@ -57,6 +57,7 @@ export const SlashItem: React.FC<SlashItemProps> = ({
       highlightClasses={highlightClasses}
       highlightStyle={highlightStyle}
       notificationDotColor={notificationDotColor}
+      variant="slash"
     >
       {hasInstructions && (
         <MarkdownViewer

--- a/src/renderer/components/chat/items/TextItem.tsx
+++ b/src/renderer/components/chat/items/TextItem.tsx
@@ -49,8 +49,9 @@ export const TextItem: React.FC<TextItemProps> = ({
       highlightClasses={highlightClasses}
       highlightStyle={highlightStyle}
       notificationDotColor={notificationDotColor}
+      variant="output"
     >
-      <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable />
+      <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable collapsible />
     </BaseItem>
   );
 };

--- a/src/renderer/components/chat/items/ThinkingItem.tsx
+++ b/src/renderer/components/chat/items/ThinkingItem.tsx
@@ -49,8 +49,9 @@ export const ThinkingItem: React.FC<ThinkingItemProps> = ({
       highlightClasses={highlightClasses}
       highlightStyle={highlightStyle}
       notificationDotColor={notificationDotColor}
+      variant="thinking"
     >
-      <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable />
+      <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable collapsible />
     </BaseItem>
   );
 };

--- a/src/renderer/components/settings/hooks/useSettingsConfig.ts
+++ b/src/renderer/components/settings/hooks/useSettingsConfig.ts
@@ -10,6 +10,7 @@ import { useStore } from '@renderer/store';
 import { useShallow } from 'zustand/react/shallow';
 
 import type { AppConfig } from '@renderer/types/data';
+import type { ThemeName } from '@shared/types/notifications';
 
 // Get the setState function from the store to update appConfig globally
 const setStoreState = useStore.setState;
@@ -27,7 +28,7 @@ export interface SafeConfig {
   general: {
     launchAtLogin: boolean;
     showDockIcon: boolean;
-    theme: 'dark' | 'light' | 'system';
+    theme: ThemeName;
     defaultTab: 'dashboard' | 'last-session';
     claudeRootPath: string | null;
     autoExpandAIGroups: boolean;

--- a/src/renderer/components/settings/hooks/useSettingsHandlers.ts
+++ b/src/renderer/components/settings/hooks/useSettingsHandlers.ts
@@ -10,6 +10,7 @@ import { useStore } from '@renderer/store';
 
 import type { RepositoryDropdownItem } from './useSettingsConfig';
 import type { AppConfig, NotificationTrigger } from '@renderer/types/data';
+import type { ThemeName } from '@shared/types/notifications';
 
 // Get the setState function from the store to update appConfig globally
 const setStoreState = useStore.setState;
@@ -29,7 +30,7 @@ interface UseSettingsHandlersProps {
 interface SettingsHandlers {
   // General handlers
   handleGeneralToggle: (key: keyof AppConfig['general'], value: boolean) => void;
-  handleThemeChange: (value: 'dark' | 'light' | 'system') => void;
+  handleThemeChange: (value: ThemeName) => void;
   handleDefaultTabChange: (value: 'dashboard' | 'last-session') => void;
 
   // Notification handlers
@@ -75,7 +76,7 @@ export function useSettingsHandlers({
   );
 
   const handleThemeChange = useCallback(
-    (value: 'dark' | 'light' | 'system') => {
+    (value: ThemeName) => {
       void updateConfig('general', { theme: value });
     },
     [updateConfig]

--- a/src/renderer/components/settings/sections/GeneralSection.tsx
+++ b/src/renderer/components/settings/sections/GeneralSection.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { api, isElectronMode } from '@renderer/api';
 import { confirm } from '@renderer/components/common/ConfirmDialog';
+import { THEME_OPTIONS } from '@renderer/constants/themes';
 import { useStore } from '@renderer/store';
 import { getFullResetState } from '@renderer/store/utils/stateResetHelpers';
 import { Check, Copy, FolderOpen, Laptop, Loader2, RotateCcw } from 'lucide-react';
@@ -15,20 +16,13 @@ import { SettingRow, SettingsSectionHeader, SettingsSelect, SettingsToggle } fro
 import type { SafeConfig } from '../hooks/useSettingsConfig';
 import type { ClaudeRootInfo, WslClaudeRootCandidate } from '@shared/types';
 import type { HttpServerStatus } from '@shared/types/api';
-import type { AppConfig } from '@shared/types/notifications';
-
-// Theme options
-const THEME_OPTIONS = [
-  { value: 'dark', label: 'Dark' },
-  { value: 'light', label: 'Light' },
-  { value: 'system', label: 'System' },
-] as const;
+import type { AppConfig, ThemeName } from '@shared/types/notifications';
 
 interface GeneralSectionProps {
   readonly safeConfig: SafeConfig;
   readonly saving: boolean;
   readonly onGeneralToggle: (key: keyof AppConfig['general'], value: boolean) => void;
-  readonly onThemeChange: (value: 'dark' | 'light' | 'system') => void;
+  readonly onThemeChange: (value: ThemeName) => void;
 }
 
 export const GeneralSection = ({

--- a/src/renderer/constants/cssVariables.ts
+++ b/src/renderer/constants/cssVariables.ts
@@ -194,6 +194,31 @@ export const CARD_TEXT_LIGHTER = 'var(--card-text-lighter)';
 export const CARD_SEPARATOR = 'var(--card-separator)';
 
 // =============================================================================
+// Step Type Colors (for colored borders and icons per step type)
+// =============================================================================
+
+/** Thinking step color (purple) */
+export const STEP_THINKING_COLOR = 'var(--step-thinking-color)';
+
+/** Output step color (blue) */
+export const STEP_OUTPUT_COLOR = 'var(--step-output-color)';
+
+/** Tool step color (amber) */
+export const STEP_TOOL_COLOR = 'var(--step-tool-color)';
+
+/** Success step color (green) */
+export const STEP_SUCCESS_COLOR = 'var(--step-success-color)';
+
+/** Error step color (red) */
+export const STEP_ERROR_COLOR = 'var(--step-error-color)';
+
+/** Slash command step color (violet) */
+export const STEP_SLASH_COLOR = 'var(--step-slash-color)';
+
+/** Subagent step color (cyan) */
+export const STEP_SUBAGENT_COLOR = 'var(--step-subagent-color)';
+
+// =============================================================================
 // Form/Input Colors (Tailwind classes for select/input options)
 // =============================================================================
 

--- a/src/renderer/constants/stepVariants.ts
+++ b/src/renderer/constants/stepVariants.ts
@@ -1,0 +1,52 @@
+/**
+ * Step variant styles for color-coded borders and icons per step type.
+ */
+
+export type StepVariant =
+  | 'thinking'
+  | 'output'
+  | 'tool'
+  | 'tool-error'
+  | 'slash'
+  | 'subagent'
+  | 'default';
+
+interface StepVariantStyle {
+  borderColor: string;
+  iconColor: string;
+}
+
+const VARIANT_STYLES: Record<StepVariant, StepVariantStyle> = {
+  thinking: {
+    borderColor: 'var(--step-thinking-color)',
+    iconColor: 'var(--step-thinking-color)',
+  },
+  output: {
+    borderColor: 'var(--step-output-color)',
+    iconColor: 'var(--step-output-color)',
+  },
+  tool: {
+    borderColor: 'var(--step-tool-color)',
+    iconColor: 'var(--step-tool-color)',
+  },
+  'tool-error': {
+    borderColor: 'var(--step-error-color)',
+    iconColor: 'var(--step-error-color)',
+  },
+  slash: {
+    borderColor: 'var(--step-slash-color)',
+    iconColor: 'var(--step-slash-color)',
+  },
+  subagent: {
+    borderColor: 'var(--step-subagent-color)',
+    iconColor: 'var(--step-subagent-color)',
+  },
+  default: {
+    borderColor: 'var(--color-border)',
+    iconColor: 'var(--tool-item-muted)',
+  },
+};
+
+export function getStepVariantStyle(variant: StepVariant = 'default'): StepVariantStyle {
+  return VARIANT_STYLES[variant];
+}

--- a/src/renderer/constants/themes.ts
+++ b/src/renderer/constants/themes.ts
@@ -1,0 +1,110 @@
+/**
+ * Theme definitions and helpers for multi-theme support.
+ */
+
+import type { ThemeName } from '@shared/types/notifications';
+
+export interface ThemeDefinition {
+  /** Config value stored in AppConfig */
+  value: ThemeName;
+  /** Display label in settings UI */
+  label: string;
+  /** CSS class added to :root */
+  cssClass: string;
+  /** Whether this is a light theme (for system resolution) */
+  isLight: boolean;
+  /** Short description */
+  description: string;
+}
+
+const THEME_DEFINITIONS: ThemeDefinition[] = [
+  {
+    value: 'dark',
+    label: 'Dark',
+    cssClass: 'dark',
+    isLight: false,
+    description: 'Default dark theme',
+  },
+  {
+    value: 'light',
+    label: 'Light',
+    cssClass: 'light',
+    isLight: true,
+    description: 'Default light theme',
+  },
+  {
+    value: 'system',
+    label: 'System',
+    cssClass: '', // resolved at runtime
+    isLight: false,
+    description: 'Follow system preference',
+  },
+  {
+    value: 'monokai',
+    label: 'Monokai',
+    cssClass: 'monokai',
+    isLight: false,
+    description: 'Warm dark with vibrant syntax colors',
+  },
+  {
+    value: 'dracula',
+    label: 'Dracula',
+    cssClass: 'dracula',
+    isLight: false,
+    description: 'Purple-accented dark theme',
+  },
+  {
+    value: 'solarized-dark',
+    label: 'Solarized Dark',
+    cssClass: 'solarized-dark',
+    isLight: false,
+    description: 'Warm dark with teal accents',
+  },
+  {
+    value: 'solarized-light',
+    label: 'Solarized Light',
+    cssClass: 'solarized-light',
+    isLight: true,
+    description: 'Warm light with teal accents',
+  },
+  {
+    value: 'nord',
+    label: 'Nord',
+    cssClass: 'nord',
+    isLight: false,
+    description: 'Cool blue-gray arctic palette',
+  },
+  {
+    value: 'github-light',
+    label: 'GitHub Light',
+    cssClass: 'github-light',
+    isLight: true,
+    description: 'Clean light theme inspired by GitHub',
+  },
+  {
+    value: 'github-dark',
+    label: 'GitHub Dark',
+    cssClass: 'github-dark',
+    isLight: false,
+    description: 'Dimmed dark theme inspired by GitHub',
+  },
+];
+
+/** Options for the settings dropdown */
+export const THEME_OPTIONS = THEME_DEFINITIONS.map((t) => ({
+  value: t.value,
+  label: t.label,
+}));
+
+/** All CSS classes that need to be removed before applying a new theme */
+export const ALL_THEME_CLASSES = THEME_DEFINITIONS.filter((t) => t.cssClass).map(
+  (t) => t.cssClass
+);
+
+/** Get the full theme definition for a theme name */
+export function getThemeDefinition(name: ThemeName): ThemeDefinition {
+  return THEME_DEFINITIONS.find((t) => t.value === name) ?? THEME_DEFINITIONS[0];
+}
+
+/** All valid theme name values (for validation) */
+export const VALID_THEME_NAMES: readonly ThemeName[] = THEME_DEFINITIONS.map((t) => t.value);

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -191,6 +191,15 @@
   --skeleton-base: #24262c;
   --skeleton-base-light: #2c2e35;
   --skeleton-base-dim: rgba(36, 38, 44, 0.6);
+
+  /* Step type colors */
+  --step-thinking-color: #a855f7;
+  --step-output-color: #3b82f6;
+  --step-tool-color: #f59e0b;
+  --step-success-color: #22c55e;
+  --step-error-color: #ef4444;
+  --step-slash-color: #8b5cf6;
+  --step-subagent-color: #06b6d4;
 }
 
 /* Light theme overrides - Warm neutral palette for eye comfort */
@@ -381,6 +390,15 @@
   --skeleton-base: #d6d8de;
   --skeleton-base-light: #cdd0d7;
   --skeleton-base-dim: rgba(205, 208, 215, 0.6);
+
+  /* Step type colors */
+  --step-thinking-color: #7c3aed;
+  --step-output-color: #2563eb;
+  --step-tool-color: #d97706;
+  --step-success-color: #16a34a;
+  --step-error-color: #dc2626;
+  --step-slash-color: #7c3aed;
+  --step-subagent-color: #0891b2;
 }
 
 * {
@@ -458,6 +476,25 @@ body {
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) transparent;
+}
+
+/* Step content expand animation */
+@keyframes expandContent {
+  from {
+    opacity: 0;
+    max-height: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    max-height: 2000px;
+    transform: translateY(0);
+  }
+}
+
+.animate-expand {
+  animation: expandContent 0.2s ease-out forwards;
+  overflow: hidden;
 }
 
 /* Dashboard skeleton shimmer animation */

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,4 +1,5 @@
 import './index.css';
+import './themes/index.css';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/src/renderer/themes/dracula.css
+++ b/src/renderer/themes/dracula.css
@@ -1,0 +1,170 @@
+/* Dracula Theme - Purple-accented dark theme */
+:root.dracula {
+  --color-surface: #282a36;
+  --color-surface-raised: #44475a;
+  --color-surface-overlay: #44475a;
+  --color-surface-sidebar: #21222c;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-subtle: rgba(255, 255, 255, 0.06);
+  --color-border-emphasis: rgba(255, 255, 255, 0.12);
+  --color-text: #f8f8f2;
+  --color-text-secondary: #bfbfbf;
+  --color-text-muted: #6272a4;
+
+  --scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  --scrollbar-thumb-active: rgba(255, 255, 255, 0.35);
+
+  --highlight-bg: rgba(241, 250, 140, 0.7);
+  --highlight-bg-inactive: rgba(241, 250, 140, 0.3);
+  --highlight-text: #282a36;
+  --highlight-text-inactive: #f8f8f2;
+  --highlight-ring: #f1fa8c;
+
+  --chat-user-bg: #44475a;
+  --chat-user-text: #bfbfbf;
+  --chat-user-border: rgba(255, 255, 255, 0.08);
+  --chat-user-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.03);
+
+  --chat-user-tag-bg: rgba(255, 255, 255, 0.08);
+  --chat-user-tag-text: #f8f8f2;
+  --chat-user-tag-border: rgba(255, 255, 255, 0.12);
+
+  --tool-item-name: #f8f8f2;
+  --tool-item-summary: #bfbfbf;
+  --tool-item-muted: #6272a4;
+  --tool-item-hover-bg: rgba(68, 71, 90, 0.5);
+
+  --chat-system-bg: rgba(68, 71, 90, 0.5);
+  --chat-system-text: #f8f8f2;
+
+  --chat-ai-border: rgba(255, 255, 255, 0.06);
+  --chat-ai-icon: #6272a4;
+
+  --code-bg: #21222c;
+  --code-header-bg: #21222c;
+  --code-border: rgba(255, 255, 255, 0.1);
+  --code-line-number: #6272a4;
+  --code-filename: #8be9fd;
+
+  --syntax-string: #f1fa8c;
+  --syntax-comment: #6272a4;
+  --syntax-number: #bd93f9;
+  --syntax-keyword: #ff79c6;
+  --syntax-type: #50fa7b;
+  --syntax-operator: #f8f8f2;
+  --syntax-function: #8be9fd;
+
+  --inline-code-bg: rgba(255, 255, 255, 0.08);
+  --inline-code-text: #f8f8f2;
+
+  --diff-added-bg: rgba(80, 250, 123, 0.15);
+  --diff-added-text: #50fa7b;
+  --diff-added-border: #50fa7b;
+  --diff-removed-bg: rgba(255, 85, 85, 0.15);
+  --diff-removed-text: #ff5555;
+  --diff-removed-border: #ff5555;
+
+  --prose-heading: #f8f8f2;
+  --prose-body: #f8f8f2;
+  --prose-muted: #bfbfbf;
+  --prose-link: #8be9fd;
+  --prose-code-bg: rgba(255, 255, 255, 0.08);
+  --prose-code-text: #f8f8f2;
+  --prose-pre-bg: #21222c;
+  --prose-pre-border: rgba(255, 255, 255, 0.1);
+  --prose-blockquote-border: rgba(189, 147, 249, 0.3);
+  --prose-table-border: rgba(255, 255, 255, 0.08);
+  --prose-table-header-bg: #44475a;
+
+  --thinking-bg: rgba(189, 147, 249, 0.15);
+  --thinking-border: rgba(189, 147, 249, 0.4);
+  --thinking-text: #bd93f9;
+  --thinking-text-muted: #d4b8ff;
+  --thinking-content-border: rgba(189, 147, 249, 0.3);
+  --thinking-content-text: #e6d5ff;
+
+  --tool-call-bg: rgba(241, 250, 140, 0.1);
+  --tool-call-border: rgba(241, 250, 140, 0.4);
+  --tool-call-text: #f1fa8c;
+  --tool-call-code-bg: rgba(241, 250, 140, 0.08);
+  --tool-call-content-border: rgba(241, 250, 140, 0.3);
+
+  --tool-result-success-bg: rgba(80, 250, 123, 0.12);
+  --tool-result-success-border: rgba(80, 250, 123, 0.4);
+  --tool-result-success-text: #50fa7b;
+  --tool-result-error-bg: rgba(255, 85, 85, 0.15);
+  --tool-result-error-border: rgba(255, 85, 85, 0.4);
+  --tool-result-error-text: #ff5555;
+
+  --output-bg: rgba(40, 42, 54, 0.3);
+  --output-border: #44475a;
+  --output-text: #f8f8f2;
+  --output-content-border: rgba(68, 71, 90, 0.5);
+
+  --badge-error-bg: #ff5555;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #f1fa8c;
+  --badge-warning-text: #282a36;
+  --badge-success-bg: #50fa7b;
+  --badge-success-text: #282a36;
+  --badge-info-bg: #8be9fd;
+  --badge-info-text: #282a36;
+  --badge-neutral-bg: #44475a;
+  --badge-neutral-text: #f8f8f2;
+
+  --tag-bg: #44475a;
+  --tag-text: #bfbfbf;
+  --tag-border: rgba(255, 255, 255, 0.08);
+
+  --skill-highlight-bg: rgba(255, 255, 255, 0.08);
+  --skill-highlight-text: #f8f8f2;
+  --path-highlight-bg: rgba(255, 255, 255, 0.08);
+  --path-highlight-text: #f8f8f2;
+
+  --interruption-bg: rgba(255, 85, 85, 0.2);
+  --interruption-border: #ff5555;
+  --interruption-text: #ff5555;
+
+  --warning-bg: rgba(255, 184, 108, 0.15);
+  --warning-border: rgba(255, 184, 108, 0.4);
+  --warning-text: #ffb86c;
+
+  --plan-exit-bg: rgba(80, 250, 123, 0.05);
+  --plan-exit-header-bg: rgba(80, 250, 123, 0.1);
+  --plan-exit-border: rgba(80, 250, 123, 0.25);
+  --plan-exit-text: #50fa7b;
+
+  --error-highlight-ring: #ff5555;
+  --error-highlight-bg: rgba(255, 85, 85, 0.2);
+
+  --kbd-bg: #44475a;
+  --kbd-border: rgba(255, 255, 255, 0.1);
+  --kbd-text: #f8f8f2;
+
+  --card-bg: #21222c;
+  --card-border: #44475a;
+  --card-header-bg: #282a36;
+  --card-header-hover: #44475a;
+  --card-icon-muted: #6272a4;
+  --card-text-light: #f8f8f2;
+  --card-text-lighter: #f8f8f2;
+  --card-separator: #44475a;
+
+  --context-btn-bg: rgba(255, 255, 255, 0.08);
+  --context-btn-bg-hover: rgba(255, 255, 255, 0.14);
+  --context-btn-active-bg: rgba(189, 147, 249, 0.45);
+  --context-btn-active-text: #f8f8f2;
+
+  --skeleton-base: #44475a;
+  --skeleton-base-light: #4f5268;
+  --skeleton-base-dim: rgba(68, 71, 90, 0.6);
+
+  --step-thinking-color: #bd93f9;
+  --step-output-color: #8be9fd;
+  --step-tool-color: #ffb86c;
+  --step-success-color: #50fa7b;
+  --step-error-color: #ff5555;
+  --step-slash-color: #ff79c6;
+  --step-subagent-color: #8be9fd;
+}

--- a/src/renderer/themes/github-dark.css
+++ b/src/renderer/themes/github-dark.css
@@ -1,0 +1,170 @@
+/* GitHub Dark Theme - Dimmed dark theme inspired by GitHub */
+:root.github-dark {
+  --color-surface: #0d1117;
+  --color-surface-raised: #161b22;
+  --color-surface-overlay: #1c2128;
+  --color-surface-sidebar: #0d1117;
+  --color-border: #30363d;
+  --color-border-subtle: #21262d;
+  --color-border-emphasis: #484f58;
+  --color-text: #e6edf3;
+  --color-text-secondary: #8d96a0;
+  --color-text-muted: #7d8590;
+
+  --scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  --scrollbar-thumb-active: rgba(255, 255, 255, 0.35);
+
+  --highlight-bg: rgba(210, 153, 34, 0.7);
+  --highlight-bg-inactive: rgba(210, 153, 34, 0.3);
+  --highlight-text: #e6edf3;
+  --highlight-text-inactive: #e6edf3;
+  --highlight-ring: #d29922;
+
+  --chat-user-bg: #161b22;
+  --chat-user-text: #8d96a0;
+  --chat-user-border: #30363d;
+  --chat-user-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.03);
+
+  --chat-user-tag-bg: rgba(255, 255, 255, 0.06);
+  --chat-user-tag-text: #e6edf3;
+  --chat-user-tag-border: #30363d;
+
+  --tool-item-name: #e6edf3;
+  --tool-item-summary: #8d96a0;
+  --tool-item-muted: #7d8590;
+  --tool-item-hover-bg: rgba(22, 27, 34, 0.5);
+
+  --chat-system-bg: rgba(22, 27, 34, 0.5);
+  --chat-system-text: #e6edf3;
+
+  --chat-ai-border: #21262d;
+  --chat-ai-icon: #7d8590;
+
+  --code-bg: #161b22;
+  --code-header-bg: #1c2128;
+  --code-border: #30363d;
+  --code-line-number: #7d8590;
+  --code-filename: #a5d6ff;
+
+  --syntax-string: #a5d6ff;
+  --syntax-comment: #7d8590;
+  --syntax-number: #79c0ff;
+  --syntax-keyword: #ff7b72;
+  --syntax-type: #d2a8ff;
+  --syntax-operator: #e6edf3;
+  --syntax-function: #d2a8ff;
+
+  --inline-code-bg: rgba(110, 118, 129, 0.2);
+  --inline-code-text: #e6edf3;
+
+  --diff-added-bg: rgba(63, 185, 80, 0.15);
+  --diff-added-text: #3fb950;
+  --diff-added-border: #3fb950;
+  --diff-removed-bg: rgba(248, 81, 73, 0.15);
+  --diff-removed-text: #f85149;
+  --diff-removed-border: #f85149;
+
+  --prose-heading: #e6edf3;
+  --prose-body: #e6edf3;
+  --prose-muted: #8d96a0;
+  --prose-link: #58a6ff;
+  --prose-code-bg: rgba(110, 118, 129, 0.2);
+  --prose-code-text: #e6edf3;
+  --prose-pre-bg: #161b22;
+  --prose-pre-border: #30363d;
+  --prose-blockquote-border: #30363d;
+  --prose-table-border: #30363d;
+  --prose-table-header-bg: #1c2128;
+
+  --thinking-bg: rgba(210, 168, 255, 0.12);
+  --thinking-border: rgba(210, 168, 255, 0.4);
+  --thinking-text: #d2a8ff;
+  --thinking-text-muted: #dbb8ff;
+  --thinking-content-border: rgba(210, 168, 255, 0.3);
+  --thinking-content-text: #e4cbff;
+
+  --tool-call-bg: rgba(210, 153, 34, 0.1);
+  --tool-call-border: rgba(210, 153, 34, 0.4);
+  --tool-call-text: #e3b341;
+  --tool-call-code-bg: rgba(210, 153, 34, 0.08);
+  --tool-call-content-border: rgba(210, 153, 34, 0.3);
+
+  --tool-result-success-bg: rgba(63, 185, 80, 0.12);
+  --tool-result-success-border: rgba(63, 185, 80, 0.4);
+  --tool-result-success-text: #3fb950;
+  --tool-result-error-bg: rgba(248, 81, 73, 0.15);
+  --tool-result-error-border: rgba(248, 81, 73, 0.4);
+  --tool-result-error-text: #f85149;
+
+  --output-bg: rgba(13, 17, 23, 0.3);
+  --output-border: #30363d;
+  --output-text: #e6edf3;
+  --output-content-border: rgba(48, 54, 61, 0.5);
+
+  --badge-error-bg: #f85149;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #d29922;
+  --badge-warning-text: #ffffff;
+  --badge-success-bg: #3fb950;
+  --badge-success-text: #ffffff;
+  --badge-info-bg: #58a6ff;
+  --badge-info-text: #ffffff;
+  --badge-neutral-bg: #30363d;
+  --badge-neutral-text: #e6edf3;
+
+  --tag-bg: #161b22;
+  --tag-text: #8d96a0;
+  --tag-border: #30363d;
+
+  --skill-highlight-bg: rgba(110, 118, 129, 0.2);
+  --skill-highlight-text: #e6edf3;
+  --path-highlight-bg: rgba(110, 118, 129, 0.2);
+  --path-highlight-text: #e6edf3;
+
+  --interruption-bg: rgba(248, 81, 73, 0.15);
+  --interruption-border: #f85149;
+  --interruption-text: #f85149;
+
+  --warning-bg: rgba(210, 153, 34, 0.15);
+  --warning-border: rgba(210, 153, 34, 0.4);
+  --warning-text: #e3b341;
+
+  --plan-exit-bg: rgba(63, 185, 80, 0.05);
+  --plan-exit-header-bg: rgba(63, 185, 80, 0.1);
+  --plan-exit-border: rgba(63, 185, 80, 0.25);
+  --plan-exit-text: #3fb950;
+
+  --error-highlight-ring: #f85149;
+  --error-highlight-bg: rgba(248, 81, 73, 0.2);
+
+  --kbd-bg: #161b22;
+  --kbd-border: #30363d;
+  --kbd-text: #e6edf3;
+
+  --card-bg: #0d1117;
+  --card-border: #30363d;
+  --card-header-bg: #161b22;
+  --card-header-hover: #1c2128;
+  --card-icon-muted: #7d8590;
+  --card-text-light: #e6edf3;
+  --card-text-lighter: #e6edf3;
+  --card-separator: #30363d;
+
+  --context-btn-bg: rgba(255, 255, 255, 0.06);
+  --context-btn-bg-hover: rgba(255, 255, 255, 0.12);
+  --context-btn-active-bg: rgba(88, 166, 255, 0.45);
+  --context-btn-active-text: #e6edf3;
+
+  --skeleton-base: #21262d;
+  --skeleton-base-light: #30363d;
+  --skeleton-base-dim: rgba(33, 38, 45, 0.6);
+
+  --step-thinking-color: #d2a8ff;
+  --step-output-color: #58a6ff;
+  --step-tool-color: #e3b341;
+  --step-success-color: #3fb950;
+  --step-error-color: #f85149;
+  --step-slash-color: #d2a8ff;
+  --step-subagent-color: #79c0ff;
+}

--- a/src/renderer/themes/github-light.css
+++ b/src/renderer/themes/github-light.css
@@ -1,0 +1,170 @@
+/* GitHub Light Theme - Clean light theme inspired by GitHub */
+:root.github-light {
+  --color-surface: #ffffff;
+  --color-surface-raised: #f6f8fa;
+  --color-surface-overlay: #f0f2f4;
+  --color-surface-sidebar: #f6f8fa;
+  --color-border: #d0d7de;
+  --color-border-subtle: #e1e4e8;
+  --color-border-emphasis: #8c959f;
+  --color-text: #1f2328;
+  --color-text-secondary: #656d76;
+  --color-text-muted: #8b949e;
+
+  --scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.28);
+  --scrollbar-thumb-active: rgba(0, 0, 0, 0.4);
+
+  --highlight-bg: #fff8c5;
+  --highlight-bg-inactive: #fff8c5aa;
+  --highlight-text: #1f2328;
+  --highlight-text-inactive: #1f2328;
+  --highlight-ring: #bf8700;
+
+  --chat-user-bg: #f6f8fa;
+  --chat-user-text: #656d76;
+  --chat-user-border: #d0d7de;
+  --chat-user-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.04);
+
+  --chat-user-tag-bg: rgba(0, 0, 0, 0.04);
+  --chat-user-tag-text: #1f2328;
+  --chat-user-tag-border: rgba(0, 0, 0, 0.08);
+
+  --tool-item-name: #1f2328;
+  --tool-item-summary: #656d76;
+  --tool-item-muted: #8b949e;
+  --tool-item-hover-bg: #f6f8fa;
+
+  --chat-system-bg: #f6f8fa;
+  --chat-system-text: #656d76;
+
+  --chat-ai-border: #d0d7de;
+  --chat-ai-icon: #8b949e;
+
+  --code-bg: #f6f8fa;
+  --code-header-bg: #f0f2f4;
+  --code-border: #d0d7de;
+  --code-line-number: #8b949e;
+  --code-filename: #0550ae;
+
+  --syntax-string: #0a3069;
+  --syntax-comment: #6e7781;
+  --syntax-number: #0550ae;
+  --syntax-keyword: #cf222e;
+  --syntax-type: #8250df;
+  --syntax-operator: #24292f;
+  --syntax-function: #8250df;
+
+  --inline-code-bg: rgba(175, 184, 193, 0.2);
+  --inline-code-text: #1f2328;
+
+  --diff-added-bg: #dafbe1;
+  --diff-added-text: #116329;
+  --diff-added-border: #1a7f37;
+  --diff-removed-bg: #ffebe9;
+  --diff-removed-text: #82071e;
+  --diff-removed-border: #cf222e;
+
+  --prose-heading: #1f2328;
+  --prose-body: #1f2328;
+  --prose-muted: #656d76;
+  --prose-link: #0969da;
+  --prose-code-bg: rgba(175, 184, 193, 0.2);
+  --prose-code-text: #1f2328;
+  --prose-pre-bg: #f6f8fa;
+  --prose-pre-border: #d0d7de;
+  --prose-blockquote-border: #d0d7de;
+  --prose-table-border: #d0d7de;
+  --prose-table-header-bg: #f0f2f4;
+
+  --thinking-bg: rgba(130, 80, 223, 0.05);
+  --thinking-border: rgba(130, 80, 223, 0.35);
+  --thinking-text: #8250df;
+  --thinking-text-muted: #8250df;
+  --thinking-content-border: rgba(130, 80, 223, 0.2);
+  --thinking-content-text: #6639ba;
+
+  --tool-call-bg: rgba(191, 135, 0, 0.06);
+  --tool-call-border: rgba(191, 135, 0, 0.35);
+  --tool-call-text: #9a6700;
+  --tool-call-code-bg: rgba(191, 135, 0, 0.05);
+  --tool-call-content-border: rgba(191, 135, 0, 0.2);
+
+  --tool-result-success-bg: #dafbe1;
+  --tool-result-success-border: #4ac26b;
+  --tool-result-success-text: #116329;
+  --tool-result-error-bg: #ffebe9;
+  --tool-result-error-border: #ff8182;
+  --tool-result-error-text: #82071e;
+
+  --output-bg: #f6f8fa;
+  --output-border: #d0d7de;
+  --output-text: #1f2328;
+  --output-content-border: #d0d7de;
+
+  --badge-error-bg: #cf222e;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #bf8700;
+  --badge-warning-text: #ffffff;
+  --badge-success-bg: #1a7f37;
+  --badge-success-text: #ffffff;
+  --badge-info-bg: #0969da;
+  --badge-info-text: #ffffff;
+  --badge-neutral-bg: #e1e4e8;
+  --badge-neutral-text: #1f2328;
+
+  --tag-bg: #f6f8fa;
+  --tag-text: #656d76;
+  --tag-border: #d0d7de;
+
+  --skill-highlight-bg: rgba(175, 184, 193, 0.2);
+  --skill-highlight-text: #1f2328;
+  --path-highlight-bg: rgba(175, 184, 193, 0.2);
+  --path-highlight-text: #1f2328;
+
+  --interruption-bg: #ffebe9;
+  --interruption-border: #cf222e;
+  --interruption-text: #82071e;
+
+  --warning-bg: #fff8c5;
+  --warning-border: #bf8700;
+  --warning-text: #9a6700;
+
+  --plan-exit-bg: #dafbe1;
+  --plan-exit-header-bg: rgba(74, 194, 107, 0.15);
+  --plan-exit-border: #4ac26b;
+  --plan-exit-text: #116329;
+
+  --error-highlight-ring: #cf222e;
+  --error-highlight-bg: rgba(207, 34, 46, 0.12);
+
+  --kbd-bg: #f6f8fa;
+  --kbd-border: #d0d7de;
+  --kbd-text: #1f2328;
+
+  --card-bg: #ffffff;
+  --card-border: #d0d7de;
+  --card-header-bg: #f6f8fa;
+  --card-header-hover: #f0f2f4;
+  --card-icon-muted: #8b949e;
+  --card-text-light: #656d76;
+  --card-text-lighter: #1f2328;
+  --card-separator: #d0d7de;
+
+  --context-btn-bg: rgba(0, 0, 0, 0.06);
+  --context-btn-bg-hover: rgba(0, 0, 0, 0.1);
+  --context-btn-active-bg: rgba(9, 105, 218, 0.35);
+  --context-btn-active-text: #0550ae;
+
+  --skeleton-base: #e1e4e8;
+  --skeleton-base-light: #d8dbe0;
+  --skeleton-base-dim: rgba(225, 228, 232, 0.6);
+
+  --step-thinking-color: #8250df;
+  --step-output-color: #0969da;
+  --step-tool-color: #bf8700;
+  --step-success-color: #1a7f37;
+  --step-error-color: #cf222e;
+  --step-slash-color: #8250df;
+  --step-subagent-color: #0969da;
+}

--- a/src/renderer/themes/index.css
+++ b/src/renderer/themes/index.css
@@ -1,0 +1,8 @@
+/* Theme barrel import - imports all theme CSS files */
+@import './monokai.css';
+@import './dracula.css';
+@import './solarized-dark.css';
+@import './solarized-light.css';
+@import './nord.css';
+@import './github-light.css';
+@import './github-dark.css';

--- a/src/renderer/themes/monokai.css
+++ b/src/renderer/themes/monokai.css
@@ -1,0 +1,170 @@
+/* Monokai Theme - Warm dark with vibrant syntax colors */
+:root.monokai {
+  --color-surface: #272822;
+  --color-surface-raised: #3e3d32;
+  --color-surface-overlay: #3e3d32;
+  --color-surface-sidebar: #1e1f1c;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-subtle: rgba(255, 255, 255, 0.06);
+  --color-border-emphasis: rgba(255, 255, 255, 0.12);
+  --color-text: #f8f8f2;
+  --color-text-secondary: #a6a69c;
+  --color-text-muted: #75715e;
+
+  --scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  --scrollbar-thumb-active: rgba(255, 255, 255, 0.35);
+
+  --highlight-bg: rgba(230, 219, 116, 0.7);
+  --highlight-bg-inactive: rgba(230, 219, 116, 0.3);
+  --highlight-text: #272822;
+  --highlight-text-inactive: #f8f8f2;
+  --highlight-ring: #e6db74;
+
+  --chat-user-bg: #3e3d32;
+  --chat-user-text: #a6a69c;
+  --chat-user-border: rgba(255, 255, 255, 0.08);
+  --chat-user-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.03);
+
+  --chat-user-tag-bg: rgba(255, 255, 255, 0.08);
+  --chat-user-tag-text: #f8f8f2;
+  --chat-user-tag-border: rgba(255, 255, 255, 0.12);
+
+  --tool-item-name: #f8f8f2;
+  --tool-item-summary: #a6a69c;
+  --tool-item-muted: #75715e;
+  --tool-item-hover-bg: rgba(62, 61, 50, 0.5);
+
+  --chat-system-bg: rgba(62, 61, 50, 0.5);
+  --chat-system-text: #f8f8f2;
+
+  --chat-ai-border: rgba(255, 255, 255, 0.06);
+  --chat-ai-icon: #75715e;
+
+  --code-bg: #1e1f1c;
+  --code-header-bg: #1e1f1c;
+  --code-border: rgba(255, 255, 255, 0.1);
+  --code-line-number: #75715e;
+  --code-filename: #66d9ef;
+
+  --syntax-string: #e6db74;
+  --syntax-comment: #75715e;
+  --syntax-number: #ae81ff;
+  --syntax-keyword: #f92672;
+  --syntax-type: #a6e22e;
+  --syntax-operator: #f8f8f2;
+  --syntax-function: #66d9ef;
+
+  --inline-code-bg: rgba(255, 255, 255, 0.08);
+  --inline-code-text: #f8f8f2;
+
+  --diff-added-bg: rgba(166, 226, 46, 0.15);
+  --diff-added-text: #a6e22e;
+  --diff-added-border: #a6e22e;
+  --diff-removed-bg: rgba(249, 38, 114, 0.15);
+  --diff-removed-text: #f92672;
+  --diff-removed-border: #f92672;
+
+  --prose-heading: #f8f8f2;
+  --prose-body: #f8f8f2;
+  --prose-muted: #a6a69c;
+  --prose-link: #66d9ef;
+  --prose-code-bg: rgba(255, 255, 255, 0.08);
+  --prose-code-text: #f8f8f2;
+  --prose-pre-bg: #1e1f1c;
+  --prose-pre-border: rgba(255, 255, 255, 0.1);
+  --prose-blockquote-border: rgba(255, 255, 255, 0.1);
+  --prose-table-border: rgba(255, 255, 255, 0.08);
+  --prose-table-header-bg: #3e3d32;
+
+  --thinking-bg: rgba(174, 129, 255, 0.15);
+  --thinking-border: rgba(174, 129, 255, 0.4);
+  --thinking-text: #ae81ff;
+  --thinking-text-muted: #c8a8ff;
+  --thinking-content-border: rgba(174, 129, 255, 0.3);
+  --thinking-content-text: #e0d0ff;
+
+  --tool-call-bg: rgba(230, 219, 116, 0.12);
+  --tool-call-border: rgba(230, 219, 116, 0.4);
+  --tool-call-text: #e6db74;
+  --tool-call-code-bg: rgba(230, 219, 116, 0.1);
+  --tool-call-content-border: rgba(230, 219, 116, 0.3);
+
+  --tool-result-success-bg: rgba(166, 226, 46, 0.12);
+  --tool-result-success-border: rgba(166, 226, 46, 0.4);
+  --tool-result-success-text: #a6e22e;
+  --tool-result-error-bg: rgba(249, 38, 114, 0.15);
+  --tool-result-error-border: rgba(249, 38, 114, 0.4);
+  --tool-result-error-text: #f92672;
+
+  --output-bg: rgba(39, 40, 34, 0.3);
+  --output-border: #3e3d32;
+  --output-text: #f8f8f2;
+  --output-content-border: rgba(62, 61, 50, 0.5);
+
+  --badge-error-bg: #f92672;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #e6db74;
+  --badge-warning-text: #272822;
+  --badge-success-bg: #a6e22e;
+  --badge-success-text: #272822;
+  --badge-info-bg: #66d9ef;
+  --badge-info-text: #272822;
+  --badge-neutral-bg: #3e3d32;
+  --badge-neutral-text: #f8f8f2;
+
+  --tag-bg: #3e3d32;
+  --tag-text: #a6a69c;
+  --tag-border: rgba(255, 255, 255, 0.08);
+
+  --skill-highlight-bg: rgba(255, 255, 255, 0.08);
+  --skill-highlight-text: #f8f8f2;
+  --path-highlight-bg: rgba(255, 255, 255, 0.08);
+  --path-highlight-text: #f8f8f2;
+
+  --interruption-bg: rgba(249, 38, 114, 0.2);
+  --interruption-border: #f92672;
+  --interruption-text: #f92672;
+
+  --warning-bg: rgba(230, 219, 116, 0.15);
+  --warning-border: rgba(230, 219, 116, 0.4);
+  --warning-text: #e6db74;
+
+  --plan-exit-bg: rgba(166, 226, 46, 0.05);
+  --plan-exit-header-bg: rgba(166, 226, 46, 0.1);
+  --plan-exit-border: rgba(166, 226, 46, 0.25);
+  --plan-exit-text: #a6e22e;
+
+  --error-highlight-ring: #f92672;
+  --error-highlight-bg: rgba(249, 38, 114, 0.2);
+
+  --kbd-bg: #3e3d32;
+  --kbd-border: rgba(255, 255, 255, 0.1);
+  --kbd-text: #f8f8f2;
+
+  --card-bg: #1e1f1c;
+  --card-border: #3e3d32;
+  --card-header-bg: #272822;
+  --card-header-hover: #3e3d32;
+  --card-icon-muted: #75715e;
+  --card-text-light: #f8f8f2;
+  --card-text-lighter: #f8f8f2;
+  --card-separator: #3e3d32;
+
+  --context-btn-bg: rgba(255, 255, 255, 0.08);
+  --context-btn-bg-hover: rgba(255, 255, 255, 0.14);
+  --context-btn-active-bg: rgba(249, 38, 114, 0.45);
+  --context-btn-active-text: #f8f8f2;
+
+  --skeleton-base: #3e3d32;
+  --skeleton-base-light: #49483e;
+  --skeleton-base-dim: rgba(62, 61, 50, 0.6);
+
+  --step-thinking-color: #ae81ff;
+  --step-output-color: #66d9ef;
+  --step-tool-color: #e6db74;
+  --step-success-color: #a6e22e;
+  --step-error-color: #f92672;
+  --step-slash-color: #ae81ff;
+  --step-subagent-color: #66d9ef;
+}

--- a/src/renderer/themes/nord.css
+++ b/src/renderer/themes/nord.css
@@ -1,0 +1,170 @@
+/* Nord Theme - Cool blue-gray arctic palette */
+:root.nord {
+  --color-surface: #2e3440;
+  --color-surface-raised: #3b4252;
+  --color-surface-overlay: #3b4252;
+  --color-surface-sidebar: #272c36;
+  --color-border: rgba(216, 222, 233, 0.1);
+  --color-border-subtle: rgba(216, 222, 233, 0.06);
+  --color-border-emphasis: rgba(216, 222, 233, 0.15);
+  --color-text: #eceff4;
+  --color-text-secondary: #d8dee9;
+  --color-text-muted: #7b88a1;
+
+  --scrollbar-thumb: rgba(216, 222, 233, 0.15);
+  --scrollbar-thumb-hover: rgba(216, 222, 233, 0.25);
+  --scrollbar-thumb-active: rgba(216, 222, 233, 0.35);
+
+  --highlight-bg: rgba(235, 203, 139, 0.7);
+  --highlight-bg-inactive: rgba(235, 203, 139, 0.3);
+  --highlight-text: #2e3440;
+  --highlight-text-inactive: #eceff4;
+  --highlight-ring: #ebcb8b;
+
+  --chat-user-bg: #3b4252;
+  --chat-user-text: #d8dee9;
+  --chat-user-border: rgba(216, 222, 233, 0.1);
+  --chat-user-shadow: 0 1px 0 0 rgba(216, 222, 233, 0.03);
+
+  --chat-user-tag-bg: rgba(216, 222, 233, 0.08);
+  --chat-user-tag-text: #eceff4;
+  --chat-user-tag-border: rgba(216, 222, 233, 0.12);
+
+  --tool-item-name: #eceff4;
+  --tool-item-summary: #d8dee9;
+  --tool-item-muted: #7b88a1;
+  --tool-item-hover-bg: rgba(59, 66, 82, 0.5);
+
+  --chat-system-bg: rgba(59, 66, 82, 0.5);
+  --chat-system-text: #eceff4;
+
+  --chat-ai-border: rgba(216, 222, 233, 0.08);
+  --chat-ai-icon: #7b88a1;
+
+  --code-bg: #272c36;
+  --code-header-bg: #272c36;
+  --code-border: rgba(216, 222, 233, 0.1);
+  --code-line-number: #616e88;
+  --code-filename: #88c0d0;
+
+  --syntax-string: #a3be8c;
+  --syntax-comment: #616e88;
+  --syntax-number: #b48ead;
+  --syntax-keyword: #81a1c1;
+  --syntax-type: #ebcb8b;
+  --syntax-operator: #d8dee9;
+  --syntax-function: #88c0d0;
+
+  --inline-code-bg: rgba(216, 222, 233, 0.08);
+  --inline-code-text: #eceff4;
+
+  --diff-added-bg: rgba(163, 190, 140, 0.15);
+  --diff-added-text: #a3be8c;
+  --diff-added-border: #a3be8c;
+  --diff-removed-bg: rgba(191, 97, 106, 0.15);
+  --diff-removed-text: #bf616a;
+  --diff-removed-border: #bf616a;
+
+  --prose-heading: #eceff4;
+  --prose-body: #e5e9f0;
+  --prose-muted: #d8dee9;
+  --prose-link: #88c0d0;
+  --prose-code-bg: rgba(216, 222, 233, 0.08);
+  --prose-code-text: #eceff4;
+  --prose-pre-bg: #272c36;
+  --prose-pre-border: rgba(216, 222, 233, 0.1);
+  --prose-blockquote-border: rgba(129, 161, 193, 0.3);
+  --prose-table-border: rgba(216, 222, 233, 0.1);
+  --prose-table-header-bg: #3b4252;
+
+  --thinking-bg: rgba(180, 142, 173, 0.15);
+  --thinking-border: rgba(180, 142, 173, 0.4);
+  --thinking-text: #b48ead;
+  --thinking-text-muted: #c9a3c4;
+  --thinking-content-border: rgba(180, 142, 173, 0.3);
+  --thinking-content-text: #d8bcd4;
+
+  --tool-call-bg: rgba(235, 203, 139, 0.1);
+  --tool-call-border: rgba(235, 203, 139, 0.4);
+  --tool-call-text: #ebcb8b;
+  --tool-call-code-bg: rgba(235, 203, 139, 0.08);
+  --tool-call-content-border: rgba(235, 203, 139, 0.3);
+
+  --tool-result-success-bg: rgba(163, 190, 140, 0.12);
+  --tool-result-success-border: rgba(163, 190, 140, 0.4);
+  --tool-result-success-text: #a3be8c;
+  --tool-result-error-bg: rgba(191, 97, 106, 0.15);
+  --tool-result-error-border: rgba(191, 97, 106, 0.4);
+  --tool-result-error-text: #bf616a;
+
+  --output-bg: rgba(46, 52, 64, 0.3);
+  --output-border: #3b4252;
+  --output-text: #e5e9f0;
+  --output-content-border: rgba(59, 66, 82, 0.5);
+
+  --badge-error-bg: #bf616a;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #ebcb8b;
+  --badge-warning-text: #2e3440;
+  --badge-success-bg: #a3be8c;
+  --badge-success-text: #2e3440;
+  --badge-info-bg: #88c0d0;
+  --badge-info-text: #2e3440;
+  --badge-neutral-bg: #3b4252;
+  --badge-neutral-text: #eceff4;
+
+  --tag-bg: #3b4252;
+  --tag-text: #d8dee9;
+  --tag-border: rgba(216, 222, 233, 0.1);
+
+  --skill-highlight-bg: rgba(216, 222, 233, 0.08);
+  --skill-highlight-text: #eceff4;
+  --path-highlight-bg: rgba(216, 222, 233, 0.08);
+  --path-highlight-text: #eceff4;
+
+  --interruption-bg: rgba(191, 97, 106, 0.2);
+  --interruption-border: #bf616a;
+  --interruption-text: #bf616a;
+
+  --warning-bg: rgba(208, 135, 112, 0.15);
+  --warning-border: rgba(208, 135, 112, 0.4);
+  --warning-text: #d08770;
+
+  --plan-exit-bg: rgba(163, 190, 140, 0.05);
+  --plan-exit-header-bg: rgba(163, 190, 140, 0.1);
+  --plan-exit-border: rgba(163, 190, 140, 0.25);
+  --plan-exit-text: #a3be8c;
+
+  --error-highlight-ring: #bf616a;
+  --error-highlight-bg: rgba(191, 97, 106, 0.2);
+
+  --kbd-bg: #3b4252;
+  --kbd-border: rgba(216, 222, 233, 0.1);
+  --kbd-text: #eceff4;
+
+  --card-bg: #272c36;
+  --card-border: #3b4252;
+  --card-header-bg: #2e3440;
+  --card-header-hover: #3b4252;
+  --card-icon-muted: #616e88;
+  --card-text-light: #e5e9f0;
+  --card-text-lighter: #eceff4;
+  --card-separator: #3b4252;
+
+  --context-btn-bg: rgba(216, 222, 233, 0.08);
+  --context-btn-bg-hover: rgba(216, 222, 233, 0.14);
+  --context-btn-active-bg: rgba(136, 192, 208, 0.45);
+  --context-btn-active-text: #eceff4;
+
+  --skeleton-base: #3b4252;
+  --skeleton-base-light: #434c5e;
+  --skeleton-base-dim: rgba(59, 66, 82, 0.6);
+
+  --step-thinking-color: #b48ead;
+  --step-output-color: #88c0d0;
+  --step-tool-color: #ebcb8b;
+  --step-success-color: #a3be8c;
+  --step-error-color: #bf616a;
+  --step-slash-color: #81a1c1;
+  --step-subagent-color: #8fbcbb;
+}

--- a/src/renderer/themes/solarized-dark.css
+++ b/src/renderer/themes/solarized-dark.css
@@ -1,0 +1,170 @@
+/* Solarized Dark Theme - Warm dark with teal/blue accents */
+:root.solarized-dark {
+  --color-surface: #002b36;
+  --color-surface-raised: #073642;
+  --color-surface-overlay: #073642;
+  --color-surface-sidebar: #001e26;
+  --color-border: rgba(131, 148, 150, 0.2);
+  --color-border-subtle: rgba(131, 148, 150, 0.12);
+  --color-border-emphasis: rgba(131, 148, 150, 0.3);
+  --color-text: #eee8d5;
+  --color-text-secondary: #93a1a1;
+  --color-text-muted: #657b83;
+
+  --scrollbar-thumb: rgba(147, 161, 161, 0.2);
+  --scrollbar-thumb-hover: rgba(147, 161, 161, 0.3);
+  --scrollbar-thumb-active: rgba(147, 161, 161, 0.4);
+
+  --highlight-bg: rgba(181, 137, 0, 0.7);
+  --highlight-bg-inactive: rgba(181, 137, 0, 0.3);
+  --highlight-text: #fdf6e3;
+  --highlight-text-inactive: #eee8d5;
+  --highlight-ring: #b58900;
+
+  --chat-user-bg: #073642;
+  --chat-user-text: #93a1a1;
+  --chat-user-border: rgba(131, 148, 150, 0.15);
+  --chat-user-shadow: 0 1px 0 0 rgba(131, 148, 150, 0.05);
+
+  --chat-user-tag-bg: rgba(147, 161, 161, 0.1);
+  --chat-user-tag-text: #eee8d5;
+  --chat-user-tag-border: rgba(147, 161, 161, 0.15);
+
+  --tool-item-name: #eee8d5;
+  --tool-item-summary: #93a1a1;
+  --tool-item-muted: #657b83;
+  --tool-item-hover-bg: rgba(7, 54, 66, 0.5);
+
+  --chat-system-bg: rgba(7, 54, 66, 0.5);
+  --chat-system-text: #eee8d5;
+
+  --chat-ai-border: rgba(131, 148, 150, 0.12);
+  --chat-ai-icon: #657b83;
+
+  --code-bg: #001e26;
+  --code-header-bg: #001e26;
+  --code-border: rgba(131, 148, 150, 0.15);
+  --code-line-number: #586e75;
+  --code-filename: #268bd2;
+
+  --syntax-string: #2aa198;
+  --syntax-comment: #586e75;
+  --syntax-number: #d33682;
+  --syntax-keyword: #859900;
+  --syntax-type: #b58900;
+  --syntax-operator: #93a1a1;
+  --syntax-function: #268bd2;
+
+  --inline-code-bg: rgba(147, 161, 161, 0.1);
+  --inline-code-text: #eee8d5;
+
+  --diff-added-bg: rgba(133, 153, 0, 0.15);
+  --diff-added-text: #859900;
+  --diff-added-border: #859900;
+  --diff-removed-bg: rgba(220, 50, 47, 0.15);
+  --diff-removed-text: #dc322f;
+  --diff-removed-border: #dc322f;
+
+  --prose-heading: #fdf6e3;
+  --prose-body: #eee8d5;
+  --prose-muted: #93a1a1;
+  --prose-link: #268bd2;
+  --prose-code-bg: rgba(147, 161, 161, 0.1);
+  --prose-code-text: #eee8d5;
+  --prose-pre-bg: #001e26;
+  --prose-pre-border: rgba(131, 148, 150, 0.15);
+  --prose-blockquote-border: rgba(131, 148, 150, 0.2);
+  --prose-table-border: rgba(131, 148, 150, 0.15);
+  --prose-table-header-bg: #073642;
+
+  --thinking-bg: rgba(108, 113, 196, 0.15);
+  --thinking-border: rgba(108, 113, 196, 0.4);
+  --thinking-text: #6c71c4;
+  --thinking-text-muted: #8a8ed4;
+  --thinking-content-border: rgba(108, 113, 196, 0.3);
+  --thinking-content-text: #b0b3e0;
+
+  --tool-call-bg: rgba(181, 137, 0, 0.12);
+  --tool-call-border: rgba(181, 137, 0, 0.4);
+  --tool-call-text: #b58900;
+  --tool-call-code-bg: rgba(181, 137, 0, 0.08);
+  --tool-call-content-border: rgba(181, 137, 0, 0.3);
+
+  --tool-result-success-bg: rgba(133, 153, 0, 0.12);
+  --tool-result-success-border: rgba(133, 153, 0, 0.4);
+  --tool-result-success-text: #859900;
+  --tool-result-error-bg: rgba(220, 50, 47, 0.15);
+  --tool-result-error-border: rgba(220, 50, 47, 0.4);
+  --tool-result-error-text: #dc322f;
+
+  --output-bg: rgba(0, 43, 54, 0.3);
+  --output-border: #073642;
+  --output-text: #eee8d5;
+  --output-content-border: rgba(7, 54, 66, 0.5);
+
+  --badge-error-bg: #dc322f;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #b58900;
+  --badge-warning-text: #ffffff;
+  --badge-success-bg: #859900;
+  --badge-success-text: #ffffff;
+  --badge-info-bg: #268bd2;
+  --badge-info-text: #ffffff;
+  --badge-neutral-bg: #073642;
+  --badge-neutral-text: #eee8d5;
+
+  --tag-bg: #073642;
+  --tag-text: #93a1a1;
+  --tag-border: rgba(131, 148, 150, 0.15);
+
+  --skill-highlight-bg: rgba(147, 161, 161, 0.1);
+  --skill-highlight-text: #eee8d5;
+  --path-highlight-bg: rgba(147, 161, 161, 0.1);
+  --path-highlight-text: #eee8d5;
+
+  --interruption-bg: rgba(220, 50, 47, 0.2);
+  --interruption-border: #dc322f;
+  --interruption-text: #dc322f;
+
+  --warning-bg: rgba(203, 75, 22, 0.15);
+  --warning-border: rgba(203, 75, 22, 0.4);
+  --warning-text: #cb4b16;
+
+  --plan-exit-bg: rgba(133, 153, 0, 0.05);
+  --plan-exit-header-bg: rgba(133, 153, 0, 0.1);
+  --plan-exit-border: rgba(133, 153, 0, 0.25);
+  --plan-exit-text: #859900;
+
+  --error-highlight-ring: #dc322f;
+  --error-highlight-bg: rgba(220, 50, 47, 0.2);
+
+  --kbd-bg: #073642;
+  --kbd-border: rgba(131, 148, 150, 0.2);
+  --kbd-text: #eee8d5;
+
+  --card-bg: #001e26;
+  --card-border: #073642;
+  --card-header-bg: #002b36;
+  --card-header-hover: #073642;
+  --card-icon-muted: #586e75;
+  --card-text-light: #eee8d5;
+  --card-text-lighter: #fdf6e3;
+  --card-separator: #073642;
+
+  --context-btn-bg: rgba(147, 161, 161, 0.1);
+  --context-btn-bg-hover: rgba(147, 161, 161, 0.16);
+  --context-btn-active-bg: rgba(38, 139, 210, 0.45);
+  --context-btn-active-text: #eee8d5;
+
+  --skeleton-base: #073642;
+  --skeleton-base-light: #0a4050;
+  --skeleton-base-dim: rgba(7, 54, 66, 0.6);
+
+  --step-thinking-color: #6c71c4;
+  --step-output-color: #268bd2;
+  --step-tool-color: #b58900;
+  --step-success-color: #859900;
+  --step-error-color: #dc322f;
+  --step-slash-color: #d33682;
+  --step-subagent-color: #2aa198;
+}

--- a/src/renderer/themes/solarized-light.css
+++ b/src/renderer/themes/solarized-light.css
@@ -1,0 +1,170 @@
+/* Solarized Light Theme - Warm light with teal/blue accents */
+:root.solarized-light {
+  --color-surface: #fdf6e3;
+  --color-surface-raised: #eee8d5;
+  --color-surface-overlay: #e8e1cc;
+  --color-surface-sidebar: #f5eed8;
+  --color-border: rgba(101, 123, 131, 0.2);
+  --color-border-subtle: rgba(101, 123, 131, 0.12);
+  --color-border-emphasis: rgba(101, 123, 131, 0.35);
+  --color-text: #073642;
+  --color-text-secondary: #586e75;
+  --color-text-muted: #93a1a1;
+
+  --scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.28);
+  --scrollbar-thumb-active: rgba(0, 0, 0, 0.4);
+
+  --highlight-bg: #b58900;
+  --highlight-bg-inactive: rgba(181, 137, 0, 0.3);
+  --highlight-text: #fdf6e3;
+  --highlight-text-inactive: #073642;
+  --highlight-ring: #b58900;
+
+  --chat-user-bg: #eee8d5;
+  --chat-user-text: #586e75;
+  --chat-user-border: rgba(101, 123, 131, 0.15);
+  --chat-user-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.04);
+
+  --chat-user-tag-bg: rgba(0, 0, 0, 0.05);
+  --chat-user-tag-text: #073642;
+  --chat-user-tag-border: rgba(0, 0, 0, 0.08);
+
+  --tool-item-name: #073642;
+  --tool-item-summary: #586e75;
+  --tool-item-muted: #93a1a1;
+  --tool-item-hover-bg: #eee8d5;
+
+  --chat-system-bg: #eee8d5;
+  --chat-system-text: #586e75;
+
+  --chat-ai-border: rgba(101, 123, 131, 0.15);
+  --chat-ai-icon: #93a1a1;
+
+  --code-bg: #eee8d5;
+  --code-header-bg: #e8e1cc;
+  --code-border: rgba(101, 123, 131, 0.2);
+  --code-line-number: #93a1a1;
+  --code-filename: #268bd2;
+
+  --syntax-string: #2aa198;
+  --syntax-comment: #93a1a1;
+  --syntax-number: #d33682;
+  --syntax-keyword: #859900;
+  --syntax-type: #b58900;
+  --syntax-operator: #657b83;
+  --syntax-function: #268bd2;
+
+  --inline-code-bg: rgba(0, 0, 0, 0.05);
+  --inline-code-text: #073642;
+
+  --diff-added-bg: rgba(133, 153, 0, 0.1);
+  --diff-added-text: #586e00;
+  --diff-added-border: #859900;
+  --diff-removed-bg: rgba(220, 50, 47, 0.1);
+  --diff-removed-text: #991b1b;
+  --diff-removed-border: #dc322f;
+
+  --prose-heading: #002b36;
+  --prose-body: #073642;
+  --prose-muted: #93a1a1;
+  --prose-link: #268bd2;
+  --prose-code-bg: rgba(0, 0, 0, 0.05);
+  --prose-code-text: #073642;
+  --prose-pre-bg: #eee8d5;
+  --prose-pre-border: rgba(101, 123, 131, 0.2);
+  --prose-blockquote-border: rgba(101, 123, 131, 0.2);
+  --prose-table-border: rgba(101, 123, 131, 0.15);
+  --prose-table-header-bg: #e8e1cc;
+
+  --thinking-bg: rgba(108, 113, 196, 0.08);
+  --thinking-border: rgba(108, 113, 196, 0.35);
+  --thinking-text: #6c71c4;
+  --thinking-text-muted: #6c71c4;
+  --thinking-content-border: rgba(108, 113, 196, 0.25);
+  --thinking-content-text: #5b609c;
+
+  --tool-call-bg: rgba(181, 137, 0, 0.08);
+  --tool-call-border: rgba(181, 137, 0, 0.35);
+  --tool-call-text: #b58900;
+  --tool-call-code-bg: rgba(181, 137, 0, 0.06);
+  --tool-call-content-border: rgba(181, 137, 0, 0.25);
+
+  --tool-result-success-bg: rgba(133, 153, 0, 0.08);
+  --tool-result-success-border: rgba(133, 153, 0, 0.35);
+  --tool-result-success-text: #586e00;
+  --tool-result-error-bg: rgba(220, 50, 47, 0.08);
+  --tool-result-error-border: rgba(220, 50, 47, 0.35);
+  --tool-result-error-text: #991b1b;
+
+  --output-bg: #eee8d5;
+  --output-border: rgba(101, 123, 131, 0.2);
+  --output-text: #073642;
+  --output-content-border: rgba(101, 123, 131, 0.15);
+
+  --badge-error-bg: #dc322f;
+  --badge-error-text: #ffffff;
+  --badge-warning-bg: #b58900;
+  --badge-warning-text: #ffffff;
+  --badge-success-bg: #859900;
+  --badge-success-text: #ffffff;
+  --badge-info-bg: #268bd2;
+  --badge-info-text: #ffffff;
+  --badge-neutral-bg: #eee8d5;
+  --badge-neutral-text: #586e75;
+
+  --tag-bg: #eee8d5;
+  --tag-text: #586e75;
+  --tag-border: rgba(101, 123, 131, 0.15);
+
+  --skill-highlight-bg: rgba(0, 0, 0, 0.05);
+  --skill-highlight-text: #073642;
+  --path-highlight-bg: rgba(0, 0, 0, 0.05);
+  --path-highlight-text: #073642;
+
+  --interruption-bg: rgba(220, 50, 47, 0.08);
+  --interruption-border: #dc322f;
+  --interruption-text: #991b1b;
+
+  --warning-bg: rgba(203, 75, 22, 0.1);
+  --warning-border: #cb4b16;
+  --warning-text: #b45309;
+
+  --plan-exit-bg: rgba(133, 153, 0, 0.05);
+  --plan-exit-header-bg: rgba(133, 153, 0, 0.08);
+  --plan-exit-border: rgba(133, 153, 0, 0.25);
+  --plan-exit-text: #586e00;
+
+  --error-highlight-ring: #dc322f;
+  --error-highlight-bg: rgba(220, 50, 47, 0.15);
+
+  --kbd-bg: #eee8d5;
+  --kbd-border: rgba(101, 123, 131, 0.25);
+  --kbd-text: #073642;
+
+  --card-bg: #fdf6e3;
+  --card-border: rgba(101, 123, 131, 0.2);
+  --card-header-bg: #eee8d5;
+  --card-header-hover: #e8e1cc;
+  --card-icon-muted: #93a1a1;
+  --card-text-light: #586e75;
+  --card-text-lighter: #073642;
+  --card-separator: rgba(101, 123, 131, 0.2);
+
+  --context-btn-bg: rgba(0, 0, 0, 0.06);
+  --context-btn-bg-hover: rgba(0, 0, 0, 0.1);
+  --context-btn-active-bg: rgba(38, 139, 210, 0.35);
+  --context-btn-active-text: #002b36;
+
+  --skeleton-base: #e8e1cc;
+  --skeleton-base-light: #ddd6be;
+  --skeleton-base-dim: rgba(232, 225, 204, 0.6);
+
+  --step-thinking-color: #6c71c4;
+  --step-output-color: #268bd2;
+  --step-tool-color: #b58900;
+  --step-success-color: #859900;
+  --step-error-color: #dc322f;
+  --step-slash-color: #d33682;
+  --step-subagent-color: #2aa198;
+}

--- a/src/shared/types/notifications.ts
+++ b/src/shared/types/notifications.ts
@@ -12,6 +12,27 @@
 import type { TriggerColor } from '@shared/constants/triggerColors';
 
 // =============================================================================
+// Theme Types
+// =============================================================================
+
+/**
+ * All available theme names.
+ * 'system' resolves to dark/light based on OS preference.
+ * Named themes apply their own CSS class on :root.
+ */
+export type ThemeName =
+  | 'dark'
+  | 'light'
+  | 'system'
+  | 'monokai'
+  | 'dracula'
+  | 'solarized-dark'
+  | 'solarized-light'
+  | 'nord'
+  | 'github-light'
+  | 'github-dark';
+
+// =============================================================================
 // Detected Error Types
 // =============================================================================
 
@@ -257,7 +278,7 @@ export interface AppConfig {
     /** Whether to show icon in dock (macOS) */
     showDockIcon: boolean;
     /** Application theme */
-    theme: 'dark' | 'light' | 'system';
+    theme: ThemeName;
     /** Default tab to show on app launch */
     defaultTab: 'dashboard' | 'last-session';
     /** Optional custom Claude root folder (auto-detected when null) */

--- a/test/main/ipc/configValidation.test.ts
+++ b/test/main/ipc/configValidation.test.ts
@@ -117,6 +117,30 @@ describe('configValidation', () => {
     }
   });
 
+  it('accepts all named theme values', () => {
+    const themes = [
+      'dark', 'light', 'system',
+      'monokai', 'dracula', 'solarized-dark', 'solarized-light',
+      'nord', 'github-light', 'github-dark',
+    ];
+
+    for (const theme of themes) {
+      const result = validateConfigUpdatePayload('general', { theme });
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.data).toEqual({ theme });
+      }
+    }
+  });
+
+  it('rejects unknown theme names', () => {
+    const result = validateConfigUpdatePayload('general', { theme: 'ocean-blue' });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('general.theme must be one of');
+    }
+  });
+
   it('accepts valid display updates', () => {
     const result = validateConfigUpdatePayload('display', {
       compactMode: true,


### PR DESCRIPTION
## Summary
- **10 named themes**: dark, light, system, monokai, dracula, solarized-dark, solarized-light, nord, github-light, github-dark — each with full CSS color palettes
- **Step variants**: color-coded left borders and icon tinting per step type (thinking, output, tool, tool-error, slash, subagent) via `StepVariant` system
- **Collapsible markdown**: long content in ThinkingItem/TextItem auto-collapses with "Show more/less"; tool output renders markdown when detected
- **Config & validation**: `ThemeName` type, updated theme validation, settings UI uses centralized theme definitions

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] `pnpm test` — all 654 tests pass (includes new theme validation tests)
- [ ] Manual: cycle through all 10 themes in Settings → General → Theme
- [ ] Manual: verify step items show colored borders (thinking=blue, tool=green, error=red, etc.)
- [ ] Manual: verify long thinking/output blocks collapse with "Show more" link
- [ ] Manual: verify markdown-formatted tool output renders as rich markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 7 new color themes: Dracula, GitHub Dark/Light, Monokai, Nord, and Solarized Dark/Light variants
  * Introduced collapsible content support in chat items
  * Added Markdown rendering for tool outputs
  * Implemented distinct visual styling for different step types (thinking, output, tool, slash, etc.)

* **Improvements**
  * Increased spacing between chat list items for better readability
  * Added smooth animation for content expansion
  * Enhanced theme configuration validation and selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->