### PR TITLE
fix: mark stale ongoing sessions as dead after 5min inactivity

### DIFF
--- a/src/main/services/discovery/ProjectScanner.ts
+++ b/src/main/services/discovery/ProjectScanner.ts
@@ -754,6 +754,12 @@ export class ProjectScanner {
         ? firstMessageTimestampMs
         : birthtimeMs;
 
+    // If messages suggest ongoing but the file hasn't been written to in 5+ minutes,
+    // the session likely crashed/was killed — mark as dead (issue #94)
+    const STALE_SESSION_THRESHOLD_MS = 5 * 60 * 1000;
+    const isOngoing =
+      metadata.isOngoing && Date.now() - effectiveMtime < STALE_SESSION_THRESHOLD_MS;
+
     return {
       id: sessionId,
       projectId,
@@ -764,7 +770,7 @@ export class ProjectScanner {
       messageTimestamp: metadata.firstUserMessage?.timestamp,
       hasSubagents,
       messageCount: metadata.messageCount,
-      isOngoing: metadata.isOngoing,
+      isOngoing,
       gitBranch: metadata.gitBranch ?? undefined,
       metadataLevel,
       contextConsumption: metadata.contextConsumption,


### PR DESCRIPTION
## Summary
- Sessions that crash, get killed, or hit usage limits stay marked as "ongoing" because their last JSONL activity is a tool_use/thinking event with no ending event
- Added an mtime staleness check in `ProjectScanner.buildSessionMetadata()` — if the session file hasn't been written to in 5+ minutes, `isOngoing` is overridden to `false`
- Uses the already-computed `effectiveMtime` so no additional I/O is needed

Closes #94

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 653 tests pass (42 files)
- [ ] Manual: kill a Claude session mid-task, verify it stops showing as ongoing after ~5 minutes
- [ ] Manual: verify actively running sessions still show the green ongoing indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved session state detection by marking sessions as inactive when their underlying file hasn't been modified in over 5 minutes, even if session metadata indicates an ongoing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->