### PR TITLE
perf: wrap leaf chat item components in React.memo()

### DIFF
--- a/src/renderer/components/chat/items/BaseItem.tsx
+++ b/src/renderer/components/chat/items/BaseItem.tsx
@@ -50,14 +50,14 @@ interface BaseItemProps {
 /**
  * Small status dot indicator.
  */
-export const StatusDot: React.FC<{ status: ItemStatus }> = ({ status }) => {
+export const StatusDot: React.FC<{ status: ItemStatus }> = React.memo(({ status }) => {
   return (
     <span
       className="inline-block size-1.5 shrink-0 rounded-full"
       style={{ backgroundColor: getStatusDotColor(status) }}
     />
   );
-};
+});
 
 // =============================================================================
 // Main Component
@@ -72,7 +72,7 @@ export const StatusDot: React.FC<{ status: ItemStatus }> = ({ status }) => {
  *
  * Used by: ThinkingItem, TextItem, LinkedToolItem, SlashItem, SubagentItem
  */
-export const BaseItem: React.FC<BaseItemProps> = ({
+export const BaseItem: React.FC<BaseItemProps> = React.memo(({
   icon,
   label,
   summary,
@@ -189,4 +189,4 @@ export const BaseItem: React.FC<BaseItemProps> = ({
       )}
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/ExecutionTrace.tsx
+++ b/src/renderer/components/chat/items/ExecutionTrace.tsx
@@ -46,7 +46,7 @@ interface ExecutionTraceProps {
 // Execution Trace Component
 // =============================================================================
 
-export const ExecutionTrace: React.FC<ExecutionTraceProps> = ({
+export const ExecutionTrace: React.FC<ExecutionTraceProps> = React.memo(({
   items,
   aiGroupId: _aiGroupId,
   highlightToolUseId,
@@ -272,4 +272,4 @@ export const ExecutionTrace: React.FC<ExecutionTraceProps> = ({
       })}
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/LinkedToolItem.tsx
+++ b/src/renderer/components/chat/items/LinkedToolItem.tsx
@@ -55,7 +55,7 @@ interface LinkedToolItemProps {
   registerRef?: (el: HTMLDivElement | null) => void;
 }
 
-export const LinkedToolItem: React.FC<LinkedToolItemProps> = ({
+export const LinkedToolItem: React.FC<LinkedToolItemProps> = React.memo(({
   linkedTool,
   onClick,
   isExpanded,
@@ -204,4 +204,4 @@ export const LinkedToolItem: React.FC<LinkedToolItemProps> = ({
       </BaseItem>
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/MetricsPill.tsx
+++ b/src/renderer/components/chat/items/MetricsPill.tsx
@@ -41,7 +41,7 @@ interface MetricsPillProps {
 // Unified Metrics Pill - Compact monospace pill with tooltip
 // =============================================================================
 
-export const MetricsPill = ({
+export const MetricsPill = React.memo(({
   mainSessionImpact,
   lastUsage,
   isolatedLabel,
@@ -213,4 +213,4 @@ export const MetricsPill = ({
         )}
     </>
   );
-};
+});

--- a/src/renderer/components/chat/items/SlashItem.tsx
+++ b/src/renderer/components/chat/items/SlashItem.tsx
@@ -30,7 +30,7 @@ interface SlashItemProps {
  * - MCP commands
  * - User-defined commands
  */
-export const SlashItem: React.FC<SlashItemProps> = ({
+export const SlashItem: React.FC<SlashItemProps> = React.memo(({
   slash,
   onClick,
   isExpanded,
@@ -68,4 +68,4 @@ export const SlashItem: React.FC<SlashItemProps> = ({
       )}
     </BaseItem>
   );
-};
+});

--- a/src/renderer/components/chat/items/SubagentItem.tsx
+++ b/src/renderer/components/chat/items/SubagentItem.tsx
@@ -60,7 +60,7 @@ interface SubagentItemProps {
 // Main Component - Linear-style DevTools Card
 // =============================================================================
 
-export const SubagentItem: React.FC<SubagentItemProps> = ({
+export const SubagentItem: React.FC<SubagentItemProps> = React.memo(({
   step,
   subagent,
   onClick,
@@ -573,4 +573,4 @@ export const SubagentItem: React.FC<SubagentItemProps> = ({
       )}
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/TeammateMessageItem.tsx
+++ b/src/renderer/components/chat/items/TeammateMessageItem.tsx
@@ -116,7 +116,7 @@ function isResendMessage(message: TeammateMessage): boolean {
  *
  * Operational noise (idle/shutdown/terminated) renders as minimal inline text.
  */
-export const TeammateMessageItem: React.FC<TeammateMessageItemProps> = ({
+export const TeammateMessageItem: React.FC<TeammateMessageItemProps> = React.memo(({
   teammateMessage,
   onClick,
   isExpanded,
@@ -260,4 +260,4 @@ export const TeammateMessageItem: React.FC<TeammateMessageItemProps> = ({
       )}
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/TextItem.tsx
+++ b/src/renderer/components/chat/items/TextItem.tsx
@@ -23,7 +23,7 @@ interface TextItemProps {
   notificationDotColor?: TriggerColor;
 }
 
-export const TextItem: React.FC<TextItemProps> = ({
+export const TextItem: React.FC<TextItemProps> = React.memo(({
   step,
   preview,
   onClick,
@@ -53,4 +53,4 @@ export const TextItem: React.FC<TextItemProps> = ({
       <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable />
     </BaseItem>
   );
-};
+});

--- a/src/renderer/components/chat/items/ThinkingItem.tsx
+++ b/src/renderer/components/chat/items/ThinkingItem.tsx
@@ -23,7 +23,7 @@ interface ThinkingItemProps {
   notificationDotColor?: TriggerColor;
 }
 
-export const ThinkingItem: React.FC<ThinkingItemProps> = ({
+export const ThinkingItem: React.FC<ThinkingItemProps> = React.memo(({
   step,
   preview,
   onClick,
@@ -53,4 +53,4 @@ export const ThinkingItem: React.FC<ThinkingItemProps> = ({
       <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable />
     </BaseItem>
   );
-};
+});

--- a/src/renderer/components/chat/items/linkedTool/DefaultToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/DefaultToolViewer.tsx
@@ -17,7 +17,7 @@ interface DefaultToolViewerProps {
   status: ItemStatus;
 }
 
-export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = ({ linkedTool, status }) => {
+export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = React.memo(({ linkedTool, status }) => {
   return (
     <>
       {/* Input Section */}
@@ -64,4 +64,4 @@ export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = ({ linkedTool
       )}
     </>
   );
-};
+});

--- a/src/renderer/components/chat/items/linkedTool/EditToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/EditToolViewer.tsx
@@ -20,7 +20,7 @@ interface EditToolViewerProps {
   status: ItemStatus;
 }
 
-export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, status }) => {
+export const EditToolViewer: React.FC<EditToolViewerProps> = React.memo(({ linkedTool, status }) => {
   const toolUseResult = linkedTool.result?.toolUseResult as Record<string, unknown> | undefined;
 
   const filePath = (toolUseResult?.filePath as string) || (linkedTool.input.file_path as string);
@@ -70,4 +70,4 @@ export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, stat
       )}
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/linkedTool/ReadToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/ReadToolViewer.tsx
@@ -14,7 +14,7 @@ interface ReadToolViewerProps {
   linkedTool: LinkedToolItem;
 }
 
-export const ReadToolViewer: React.FC<ReadToolViewerProps> = ({ linkedTool }) => {
+export const ReadToolViewer: React.FC<ReadToolViewerProps> = React.memo(({ linkedTool }) => {
   const filePath = linkedTool.input.file_path as string;
 
   // Prefer enriched toolUseResult data
@@ -62,4 +62,4 @@ export const ReadToolViewer: React.FC<ReadToolViewerProps> = ({ linkedTool }) =>
       endLine={endLine}
     />
   );
-};
+});

--- a/src/renderer/components/chat/items/linkedTool/SkillToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/SkillToolViewer.tsx
@@ -14,7 +14,7 @@ interface SkillToolViewerProps {
   linkedTool: LinkedToolItem;
 }
 
-export const SkillToolViewer: React.FC<SkillToolViewerProps> = ({ linkedTool }) => {
+export const SkillToolViewer: React.FC<SkillToolViewerProps> = React.memo(({ linkedTool }) => {
   const skillInstructions = linkedTool.skillInstructions;
   const skillName = (linkedTool.input.skill as string) || 'Unknown Skill';
 
@@ -64,4 +64,4 @@ export const SkillToolViewer: React.FC<SkillToolViewerProps> = ({ linkedTool }) 
       )}
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/linkedTool/ToolErrorDisplay.tsx
+++ b/src/renderer/components/chat/items/linkedTool/ToolErrorDisplay.tsx
@@ -16,7 +16,7 @@ interface ToolErrorDisplayProps {
   linkedTool: LinkedToolItem;
 }
 
-export const ToolErrorDisplay: React.FC<ToolErrorDisplayProps> = ({ linkedTool }) => {
+export const ToolErrorDisplay: React.FC<ToolErrorDisplayProps> = React.memo(({ linkedTool }) => {
   if (!linkedTool.result?.isError) return null;
 
   return (
@@ -40,4 +40,4 @@ export const ToolErrorDisplay: React.FC<ToolErrorDisplayProps> = ({ linkedTool }
       </div>
     </div>
   );
-};
+});

--- a/src/renderer/components/chat/items/linkedTool/WriteToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/WriteToolViewer.tsx
@@ -14,7 +14,7 @@ interface WriteToolViewerProps {
   linkedTool: LinkedToolItem;
 }
 
-export const WriteToolViewer: React.FC<WriteToolViewerProps> = ({ linkedTool }) => {
+export const WriteToolViewer: React.FC<WriteToolViewerProps> = React.memo(({ linkedTool }) => {
   const toolUseResult = linkedTool.result?.toolUseResult as Record<string, unknown> | undefined;
 
   const filePath = (toolUseResult?.filePath as string) || (linkedTool.input.file_path as string);
@@ -63,4 +63,4 @@ export const WriteToolViewer: React.FC<WriteToolViewerProps> = ({ linkedTool }) 
       )}
     </div>
   );
-};
+});


### PR DESCRIPTION
## Summary
- Wrap 16 leaf components in `React.memo()` across 15 files in `src/renderer/components/chat/items/`
- Components: BaseItem, StatusDot, ExecutionTrace, LinkedToolItem, MetricsPill, SlashItem, SubagentItem, TeammateMessageItem, TextItem, ThinkingItem, DefaultToolViewer, EditToolViewer, ReadToolViewer, SkillToolViewer, ToolErrorDisplay, WriteToolViewer

## Why
These leaf components are rendered inside virtualized lists (via `@tanstack/react-virtual`). Without `React.memo()`, every parent re-render causes all item components to re-render even when their props haven't changed. With large conversations (1000+ items), this causes significant scroll jank and unnecessary reconciliation work.

## Test plan
- [ ] Chat history renders correctly with all item types
- [ ] Scroll performance is smooth in long conversations
- [ ] Expanding/collapsing items still works
- [ ] Search highlighting still applies correctly
- [ ] Tool viewers render tool results properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized component rendering performance across chat item and linked tool viewer components to improve application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->