### PR TITLE
perf: single-pass message categorization in SessionParser

### DIFF
--- a/src/main/services/parsing/SessionParser.ts
+++ b/src/main/services/parsing/SessionParser.ts
@@ -82,21 +82,42 @@ export class SessionParser {
    * Process parsed messages into structured data.
    */
   private processMessages(messages: ParsedMessage[]): ParsedSession {
-    // Group by type
+    // Single-pass categorization instead of 8 separate filter passes
     const byType = {
-      user: messages.filter((m) => m.type === 'user'),
-      realUser: messages.filter(isParsedRealUserMessage),
-      internalUser: messages.filter(isParsedInternalUserMessage),
-      assistant: messages.filter((m) => m.type === 'assistant'),
-      system: messages.filter((m) => m.type === 'system'),
-      other: messages.filter(
-        (m) => m.type !== 'user' && m.type !== 'assistant' && m.type !== 'system'
-      ),
+      user: [] as ParsedMessage[],
+      realUser: [] as ParsedMessage[],
+      internalUser: [] as ParsedMessage[],
+      assistant: [] as ParsedMessage[],
+      system: [] as ParsedMessage[],
+      other: [] as ParsedMessage[],
     };
+    const sidechainMessages: ParsedMessage[] = [];
+    const mainMessages: ParsedMessage[] = [];
 
-    // Separate sidechain and main messages
-    const sidechainMessages = messages.filter((m) => m.isSidechain);
-    const mainMessages = messages.filter((m) => !m.isSidechain);
+    for (const m of messages) {
+      switch (m.type) {
+        case 'user':
+          byType.user.push(m);
+          if (isParsedRealUserMessage(m)) byType.realUser.push(m);
+          if (isParsedInternalUserMessage(m)) byType.internalUser.push(m);
+          break;
+        case 'assistant':
+          byType.assistant.push(m);
+          break;
+        case 'system':
+          byType.system.push(m);
+          break;
+        default:
+          byType.other.push(m);
+          break;
+      }
+
+      if (m.isSidechain) {
+        sidechainMessages.push(m);
+      } else {
+        mainMessages.push(m);
+      }
+    }
 
     // Calculate metrics
     const metrics = calculateMetrics(messages);


### PR DESCRIPTION
## Summary
- Replace 8 separate `.filter()` calls with a single `for...of` loop in `SessionParser.processMessages()`
- Messages are categorized into all applicable buckets (user, realUser, internalUser, assistant, system, other, sidechain, mainchain) in one pass

## Why
For a session with 10,000 messages, the original code iterated the array 8 times (80,000 iterations). The single-pass approach does this in exactly 10,000 iterations — an 8x reduction in loop overhead.

## Test plan
- [ ] Session parsing produces identical results (message counts per category)
- [ ] Existing tests pass: `npx vitest run test/main/services/parsing/SessionParser.test.ts`
- [ ] Sidechain/mainchain separation still correct
- [ ] Real user vs internal user classification unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal message categorization and processing logic for improved performance and code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->