### PR TITLE
perf: cache compiled regexes in TriggerMatcher

### DIFF
--- a/src/main/services/error/TriggerMatcher.ts
+++ b/src/main/services/error/TriggerMatcher.ts
@@ -12,15 +12,53 @@ import { type ContentBlock, type ParsedMessage } from '@main/types';
 import { createSafeRegExp } from '@main/utils/regexValidation';
 
 // =============================================================================
+// Regex Cache
+// =============================================================================
+
+const MAX_CACHE_SIZE = 500;
+
+/**
+ * Module-level cache for compiled RegExp objects.
+ * Key: `${pattern}\0${flags}` (null byte separator avoids collisions).
+ * Value: compiled RegExp, or null if the pattern is invalid/dangerous.
+ */
+const regexCache = new Map<string, RegExp | null>();
+
+/**
+ * Returns a cached RegExp for the given pattern and flags.
+ * Compiles and caches on first access; returns null for invalid patterns.
+ * Cache is bounded to MAX_CACHE_SIZE entries (oldest evicted first via Map insertion order).
+ */
+function getCachedRegex(pattern: string, flags: string): RegExp | null {
+  const key = `${pattern}\0${flags}`;
+  if (regexCache.has(key)) {
+    return regexCache.get(key) ?? null;
+  }
+
+  // Evict oldest entries when cache is full
+  if (regexCache.size >= MAX_CACHE_SIZE) {
+    const firstKey = regexCache.keys().next().value;
+    if (firstKey !== undefined) {
+      regexCache.delete(firstKey);
+    }
+  }
+
+  const regex = createSafeRegExp(pattern, flags);
+  regexCache.set(key, regex);
+  return regex;
+}
+
+// =============================================================================
 // Pattern Matching
 // =============================================================================
 
 /**
  * Checks if content matches a pattern.
  * Uses validated regex to prevent ReDoS attacks.
+ * Regex objects are cached to avoid recompilation on repeated calls.
  */
 export function matchesPattern(content: string, pattern: string): boolean {
-  const regex = createSafeRegExp(pattern, 'i');
+  const regex = getCachedRegex(pattern, 'i');
   if (!regex) {
     // Pattern is invalid or potentially dangerous, reject match
     return false;
@@ -31,6 +69,7 @@ export function matchesPattern(content: string, pattern: string): boolean {
 /**
  * Checks if content matches any of the ignore patterns.
  * Uses validated regex to prevent ReDoS attacks.
+ * Regex objects are cached to avoid recompilation on repeated calls.
  */
 export function matchesIgnorePatterns(content: string, ignorePatterns?: string[]): boolean {
   if (!ignorePatterns || ignorePatterns.length === 0) {
@@ -38,7 +77,7 @@ export function matchesIgnorePatterns(content: string, ignorePatterns?: string[]
   }
 
   for (const pattern of ignorePatterns) {
-    const regex = createSafeRegExp(pattern, 'i');
+    const regex = getCachedRegex(pattern, 'i');
     if (regex?.test(content)) {
       return true;
     }


### PR DESCRIPTION
## Summary
- Adds a bounded LRU-style cache (max 500 entries) for compiled `RegExp` objects in `TriggerMatcher`
- `matchesPattern()` and `matchesIgnorePatterns()` now use `getCachedRegex()` instead of recompiling via `createSafeRegExp()` on every call
- Cache key uses null-byte separator to avoid pattern/flag collisions

Addresses #95

## Test plan
- [x] All 653 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] Production build succeeds
- [x] Cache is bounded — evicts oldest entry when full

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pattern matching operations for improved performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->