### PR TITLE
perf: fix renderer heap exhaustion on long-running sessions

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,10 +19,18 @@ import {
 import { createLogger } from '@shared/utils/logger';
 import { app, BrowserWindow, ipcMain } from 'electron';
 import { existsSync } from 'fs';
+import { totalmem } from 'os';
 import { join } from 'path';
 
 import { initializeIpcHandlers, removeIpcHandlers } from './ipc/handlers';
 import { getProjectsBasePath, getTodosBasePath } from './utils/pathDecoder';
+
+// Dynamic renderer heap limit — proportional to system RAM so low-end devices
+// are not starved.  50% of total RAM, clamped to [2 GB, 4 GB].
+// Must run before app.whenReady() so the flag is picked up by the renderer.
+const totalMB = Math.floor(totalmem() / (1024 * 1024));
+const heapMB = Math.min(4096, Math.max(2048, Math.floor(totalMB * 0.5)));
+app.commandLine.appendSwitch('js-flags', `--max-old-space-size=${heapMB}`);
 
 // Window icon path for non-mac platforms.
 const getWindowIconPath = (): string | undefined => {

--- a/src/main/ipc/sessions.ts
+++ b/src/main/ipc/sessions.ts
@@ -220,39 +220,44 @@ async function handleGetSessionDetail(
     // Check cache first
     let sessionDetail = dataCache.get(cacheKey);
 
-    if (sessionDetail) {
-      return sessionDetail;
+    if (!sessionDetail) {
+      const fsType = projectScanner.getFileSystemProvider().type;
+      // In SSH mode, avoid an extra deep metadata scan before full parse.
+      const session = await projectScanner.getSessionWithOptions(safeProjectId, safeSessionId, {
+        metadataLevel: fsType === 'ssh' ? 'light' : 'deep',
+      });
+      if (!session) {
+        logger.error(`Session not found: ${sessionId}`);
+        return null;
+      }
+
+      // Parse session messages
+      const parsedSession = await sessionParser.parseSession(safeProjectId, safeSessionId);
+
+      // Resolve subagents
+      const subagents = await subagentResolver.resolveSubagents(
+        safeProjectId,
+        safeSessionId,
+        parsedSession.taskCalls,
+        parsedSession.messages
+      );
+      session.hasSubagents = subagents.length > 0;
+
+      // Build session detail with chunks
+      sessionDetail = chunkBuilder.buildSessionDetail(session, parsedSession.messages, subagents);
+
+      // Cache the result
+      dataCache.set(cacheKey, sessionDetail);
     }
 
-    const fsType = projectScanner.getFileSystemProvider().type;
-    // In SSH mode, avoid an extra deep metadata scan before full parse.
-    const session = await projectScanner.getSessionWithOptions(safeProjectId, safeSessionId, {
-      metadataLevel: fsType === 'ssh' ? 'light' : 'deep',
-    });
-    if (!session) {
-      logger.error(`Session not found: ${sessionId}`);
-      return null;
-    }
-
-    // Parse session messages
-    const parsedSession = await sessionParser.parseSession(safeProjectId, safeSessionId);
-
-    // Resolve subagents
-    const subagents = await subagentResolver.resolveSubagents(
-      safeProjectId,
-      safeSessionId,
-      parsedSession.taskCalls,
-      parsedSession.messages
-    );
-    session.hasSubagents = subagents.length > 0;
-
-    // Build session detail with chunks
-    sessionDetail = chunkBuilder.buildSessionDetail(session, parsedSession.messages, subagents);
-
-    // Cache the result
-    dataCache.set(cacheKey, sessionDetail);
-
-    return sessionDetail;
+    // Strip raw messages before IPC transfer — the renderer never uses them.
+    // Only chunks (with semantic steps) and process summaries cross the boundary.
+    // This cuts IPC serialization + renderer heap by ~50-60%.
+    return {
+      ...sessionDetail,
+      messages: [],
+      processes: sessionDetail.processes.map((p) => ({ ...p, messages: [] })),
+    };
   } catch (error) {
     logger.error(`Error in get-session-detail for ${projectId}/${sessionId}:`, error);
     return null;

--- a/src/renderer/components/chat/ChatHistory.tsx
+++ b/src/renderer/components/chat/ChatHistory.tsx
@@ -37,7 +37,7 @@ interface ChatHistoryProps {
 }
 
 export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
-  const VIRTUALIZATION_THRESHOLD = 120;
+  const VIRTUALIZATION_THRESHOLD = 30;
   const ESTIMATED_CHAT_ITEM_HEIGHT = 260;
 
   // Per-tab UI state (context panel, scroll position, expansion) from useTabUI

--- a/src/renderer/components/common/TokenUsageDisplay.tsx
+++ b/src/renderer/components/common/TokenUsageDisplay.tsx
@@ -76,22 +76,13 @@ const SessionContextSection = ({
   const contextPercent =
     totalTokens > 0 ? Math.min((adjustedContextTotal / totalTokens) * 100, 100).toFixed(1) : '0.0';
 
-  // Count accumulated injections by category
-  const claudeMdCount = contextStats.accumulatedInjections.filter(
-    (inj) => inj.category === 'claude-md'
-  ).length;
-  const mentionedFilesCount = contextStats.accumulatedInjections.filter(
-    (inj) => inj.category === 'mentioned-file'
-  ).length;
-  const toolOutputsCount = contextStats.accumulatedInjections.filter(
-    (inj) => inj.category === 'tool-output'
-  ).length;
-  const taskCoordinationCount = contextStats.accumulatedInjections.filter(
-    (inj) => inj.category === 'task-coordination'
-  ).length;
-  const userMessagesCount = contextStats.accumulatedInjections.filter(
-    (inj) => inj.category === 'user-message'
-  ).length;
+  // Use precomputed accumulated counts (avoids iterating the full injection array)
+  const counts = contextStats.accumulatedCounts;
+  const claudeMdCount = counts.claudeMd;
+  const mentionedFilesCount = counts.mentionedFiles;
+  const toolOutputsCount = counts.toolOutputs;
+  const taskCoordinationCount = counts.taskCoordination;
+  const userMessagesCount = counts.userMessages;
 
   // Calculate percentages for each category
   const claudeMdPercent =

--- a/src/renderer/components/layout/MoreMenu.tsx
+++ b/src/renderer/components/layout/MoreMenu.tsx
@@ -7,18 +7,19 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { api } from '@renderer/api';
 import { useStore } from '@renderer/store';
 import { triggerDownload } from '@renderer/utils/sessionExporter';
 import { formatShortcut } from '@renderer/utils/stringUtils';
 import { Braces, FileText, MoreHorizontal, Search, Settings, Type } from 'lucide-react';
 
-import type { SessionDetail } from '@renderer/types/data';
 import type { Tab } from '@renderer/types/tabs';
 import type { ExportFormat } from '@renderer/utils/sessionExporter';
 
 interface MoreMenuProps {
   activeTab: Tab | undefined;
-  activeTabSessionDetail: SessionDetail | null;
+  /** Whether the active tab has session data loaded (used to show export options). */
+  activeTabHasSession: boolean;
 }
 
 interface MenuItem {
@@ -31,11 +32,12 @@ interface MenuItem {
 
 export const MoreMenu = ({
   activeTab,
-  activeTabSessionDetail,
+  activeTabHasSession,
 }: Readonly<MoreMenuProps>): React.JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const [buttonHover, setButtonHover] = useState(false);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [exportLoading, setExportLoading] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const openCommandPalette = useStore((s) => s.openCommandPalette);
@@ -71,15 +73,24 @@ export const MoreMenu = ({
 
   const handleExport = useCallback(
     (format: ExportFormat) => {
-      if (activeTabSessionDetail) {
-        triggerDownload(activeTabSessionDetail, format);
-      }
+      if (activeTab?.type !== 'session' || !activeTab.projectId || !activeTab.sessionId) return;
+      const { projectId, sessionId } = activeTab;
       setIsOpen(false);
+      setExportLoading(true);
+      // Re-fetch full detail (with chunks) since we strip them from the store to save memory.
+      void api
+        .getSessionDetail(projectId, sessionId)
+        .then((detail) => {
+          if (detail) triggerDownload(detail, format);
+        })
+        .finally(() => {
+          setExportLoading(false);
+        });
     },
-    [activeTabSessionDetail]
+    [activeTab]
   );
 
-  const isSessionWithData = activeTab?.type === 'session' && activeTabSessionDetail != null;
+  const isSessionWithData = activeTab?.type === 'session' && activeTabHasSession;
 
   // Build menu sections
   const topItems: MenuItem[] = [
@@ -99,21 +110,21 @@ export const MoreMenu = ({
     ? [
         {
           id: 'export-md',
-          label: 'Export as Markdown',
+          label: exportLoading ? 'Exporting…' : 'Export as Markdown',
           icon: FileText,
           shortcut: '.md',
           onClick: () => handleExport('markdown'),
         },
         {
           id: 'export-json',
-          label: 'Export as JSON',
+          label: exportLoading ? 'Exporting…' : 'Export as JSON',
           icon: Braces,
           shortcut: '.json',
           onClick: () => handleExport('json'),
         },
         {
           id: 'export-txt',
-          label: 'Export as Plain Text',
+          label: exportLoading ? 'Exporting…' : 'Export as Plain Text',
           icon: Type,
           shortcut: '.txt',
           onClick: () => handleExport('plaintext'),

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -89,10 +89,11 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
   // Derive stable tab IDs array for SortableContext
   const tabIds = useMemo(() => openTabs.map((t) => t.id), [openTabs]);
 
-  // Derive session detail for the active tab (used by export dropdown)
-  const activeTabSessionDetail = activeTabId
-    ? (tabSessionData[activeTabId]?.sessionDetail ?? null)
-    : null;
+  // Whether the active tab has session data loaded (for export menu visibility).
+  // We no longer pass full sessionDetail here — export re-fetches on demand to save memory.
+  const activeTabHasSession = activeTabId
+    ? tabSessionData[activeTabId]?.sessionDetail != null
+    : false;
 
   // Hover states for buttons
   const [expandHover, setExpandHover] = useState(false);
@@ -395,7 +396,7 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
         </button>
 
         {/* More menu (Search, Export, Settings) */}
-        <MoreMenu activeTab={activeTab} activeTabSessionDetail={activeTabSessionDetail} />
+        <MoreMenu activeTab={activeTab} activeTabHasSession={activeTabHasSession} />
       </div>
 
       {/* Context menu */}

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -78,11 +78,33 @@ export function initializeNotificationListeners(): () => void {
     if (pendingSessionRefreshTimers.has(key)) {
       return;
     }
+
+    // Adaptive debounce: large sessions refresh less frequently to reduce memory churn.
+    // Uses the TARGET session's cached totalAIGroups so a long session in another pane
+    // doesn't force the active short session to the default interval.
+    const state = useStore.getState();
+    const tabData = Object.values(state.tabSessionData).find(
+      (td) => td?.sessionDetail?.session?.id === sessionId
+    );
+    const aiGroupCount =
+      tabData?.conversation?.totalAIGroups ??
+      (state.conversation?.items ?? []).filter((i) => i.type === 'ai').length;
+    const debounceMs =
+      aiGroupCount > 1000
+        ? 60000 // ~60s for very long sessions (24h+)
+        : aiGroupCount > 500
+          ? 30000 // ~30s for long sessions
+          : aiGroupCount > 200
+            ? 10000 // ~10s for medium sessions
+            : aiGroupCount > 100
+              ? 3000 // ~3s for moderate sessions
+              : SESSION_REFRESH_DEBOUNCE_MS; // 150ms default
+
     const timer = setTimeout(() => {
       pendingSessionRefreshTimers.delete(key);
-      const state = useStore.getState();
-      void state.refreshSessionInPlace(projectId, sessionId);
-    }, SESSION_REFRESH_DEBOUNCE_MS);
+      const latestState = useStore.getState();
+      void latestState.refreshSessionInPlace(projectId, sessionId);
+    }, debounceMs);
     pendingSessionRefreshTimers.set(key, timer);
   };
 

--- a/src/renderer/store/slices/sessionDetailSlice.ts
+++ b/src/renderer/store/slices/sessionDetailSlice.ts
@@ -9,10 +9,12 @@ import { processSessionClaudeMd } from '@renderer/utils/claudeMdTracker';
 import { processSessionContextWithPhases } from '@renderer/utils/contextTracker';
 import {
   extractFileReferences,
+  incrementalUpdateConversation,
   transformChunksToConversation,
 } from '@renderer/utils/groupTransformer';
 import { createLogger } from '@shared/utils/logger';
 
+import { batchAsync } from '../utils/batchAsync';
 import { resolveFilePath } from '../utils/pathResolution';
 
 const logger = createLogger('Store:sessionDetail');
@@ -24,6 +26,11 @@ const logger = createLogger('Store:sessionDetail');
 const sessionRefreshGeneration = new Map<string, number>();
 const sessionRefreshInFlight = new Set<string>();
 const sessionRefreshQueued = new Set<string>();
+/**
+ * Lightweight fingerprint per session: "chunkCount:lastChunkMsgCount".
+ * When unchanged, the refresh can skip the expensive transformation entirely.
+ */
+const sessionChunkFingerprint = new Map<string, string>();
 let sessionDetailFetchGeneration = 0;
 let agentConfigsCachedForProject = '';
 
@@ -186,17 +193,23 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
           ? transformChunksToConversation(enhancedChunks, detail.processes, isOngoing)
           : null;
 
+      // Free the raw chunk arrays — they are not needed after conversation is built.
+      // Storing them would hold GBs of data for long sessions. Export re-fetches on demand.
+      const slimDetail = detail ? { ...detail, chunks: [], processes: [] } : null;
+
       // Initialize visibleAIGroupId to first AI Group if available
       const firstAIItem = conversation?.items?.find((item) => item.type === 'ai');
       const firstAIGroupId = firstAIItem?.type === 'ai' ? firstAIItem.group.id : null;
       const firstAIGroup = firstAIItem?.type === 'ai' ? firstAIItem.group : null;
 
-      // Compute CLAUDE.md stats for the session
+      // =====================================================================
+      // Phase 1: Immediate render — push conversation to store so the UI
+      // can display chat messages without waiting for context stats.
+      // =====================================================================
+
       const projectRoot = detail?.session?.projectPath ?? '';
       const { connectionMode } = get();
-      let claudeMdStats: Map<string, ClaudeMdStats> | null = null;
-      let contextStats: Map<string, ContextStats> | null = null;
-      let phaseInfo: ContextPhaseInfo | null = null;
+
       // Fetch agent configs from .claude/agents/ (only when project changes).
       // Fire-and-forget: don't block transcript rendering — color badges update async.
       if (connectionMode !== 'ssh' && projectRoot && projectRoot !== agentConfigsCachedForProject) {
@@ -210,172 +223,6 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
             logger.error('Failed to read agent configs:', err);
             agentConfigsCachedForProject = ''; // Reset so it retries next time
           });
-      }
-
-      if (connectionMode !== 'ssh' && conversation?.items) {
-        // Fetch real CLAUDE.md token data
-        let claudeMdTokenData: Record<string, ClaudeMdFileInfo> = {};
-        try {
-          claudeMdTokenData = await api.readClaudeMdFiles(projectRoot);
-          if (requestGeneration !== sessionDetailFetchGeneration) {
-            return;
-          }
-        } catch (err) {
-          logger.error('Failed to read CLAUDE.md files:', err);
-        }
-
-        claudeMdStats = processSessionClaudeMd(conversation.items, projectRoot, claudeMdTokenData);
-
-        // Fetch real tokens for directory CLAUDE.md files
-        // Directory injections are detected dynamically from Read tool paths and aren't in pre-fetched tokenData
-        // We need to validate these BEFORE calling processSessionContext so both trackers have consistent data
-        const directoryTokenData: Record<string, ClaudeMdFileInfo> = {}; // Validated directory token data
-
-        if (claudeMdStats && claudeMdStats.size > 0) {
-          // Collect all unique directory injection paths
-          const directoryPaths = new Set<string>();
-          for (const stats of claudeMdStats.values()) {
-            for (const injection of stats.accumulatedInjections) {
-              if (injection.source === 'directory') {
-                directoryPaths.add(injection.path);
-              }
-            }
-          }
-
-          // Fetch real tokens for each directory path (parallel IPC calls)
-          if (directoryPaths.size > 0) {
-            const directoryTokens = new Map<string, number>();
-            const nonExistentPaths = new Set<string>();
-
-            const directoryResults = await Promise.all(
-              Array.from(directoryPaths).map(async (fullPath) => {
-                try {
-                  const dirPath = fullPath.replace(/[\\/]CLAUDE\.md$/, '');
-                  const fileInfo = await api.readDirectoryClaudeMd(dirPath);
-                  return { fullPath, fileInfo, error: false };
-                } catch (err) {
-                  logger.error('Failed to read directory CLAUDE.md:', fullPath, err);
-                  return { fullPath, fileInfo: null, error: true };
-                }
-              })
-            );
-            if (requestGeneration !== sessionDetailFetchGeneration) {
-              return;
-            }
-
-            for (const { fullPath, fileInfo, error } of directoryResults) {
-              if (error || !fileInfo) {
-                nonExistentPaths.add(fullPath);
-              } else if (fileInfo.exists && fileInfo.estimatedTokens > 0) {
-                directoryTokens.set(fullPath, fileInfo.estimatedTokens);
-                directoryTokenData[fullPath] = fileInfo;
-              } else {
-                nonExistentPaths.add(fullPath);
-              }
-            }
-
-            // Update stats: set real tokens and REMOVE non-existent files
-            for (const [, stats] of claudeMdStats.entries()) {
-              // Filter out non-existent paths
-              stats.accumulatedInjections = stats.accumulatedInjections.filter(
-                (inj) => inj.source !== 'directory' || !nonExistentPaths.has(inj.path)
-              );
-              stats.newInjections = stats.newInjections.filter(
-                (inj) => inj.source !== 'directory' || !nonExistentPaths.has(inj.path)
-              );
-
-              // Update tokens for existing files
-              for (const injection of stats.accumulatedInjections) {
-                if (injection.source === 'directory' && directoryTokens.has(injection.path)) {
-                  injection.estimatedTokens = directoryTokens.get(injection.path)!;
-                }
-              }
-              for (const injection of stats.newInjections) {
-                if (injection.source === 'directory' && directoryTokens.has(injection.path)) {
-                  injection.estimatedTokens = directoryTokens.get(injection.path)!;
-                }
-              }
-
-              // Recalculate totals and counts
-              stats.totalEstimatedTokens = stats.accumulatedInjections.reduce(
-                (sum, inj) => sum + inj.estimatedTokens,
-                0
-              );
-              stats.accumulatedCount = stats.accumulatedInjections.length;
-              stats.newCount = stats.newInjections.length;
-            }
-          }
-        }
-
-        // Compute unified context stats (CLAUDE.md + mentioned files + tool outputs)
-        // Extract all mentioned file paths from user groups
-        const mentionedFilePaths = new Set<string>();
-        for (const item of conversation.items) {
-          if (item.type === 'user' && item.group.content.fileReferences) {
-            for (const ref of item.group.content.fileReferences) {
-              // Use resolveFilePath to properly handle ./ and ../ prefixes
-              const absolutePath = resolveFilePath(projectRoot, ref.path);
-              mentionedFilePaths.add(absolutePath);
-            }
-          }
-        }
-
-        // Also collect @-mentions from isMeta:true user messages in AI responses
-        for (const item of conversation.items) {
-          if (item.type === 'ai') {
-            for (const msg of item.group.responses) {
-              if (msg.type !== 'user') continue;
-              let text = '';
-              if (typeof msg.content === 'string') {
-                text = msg.content;
-              } else if (Array.isArray(msg.content)) {
-                for (const block of msg.content) {
-                  if (block.type === 'text' && block.text) text += block.text;
-                }
-              }
-              if (text) {
-                for (const ref of extractFileReferences(text)) {
-                  const absolutePath = resolveFilePath(projectRoot, ref.path);
-                  mentionedFilePaths.add(absolutePath);
-                }
-              }
-            }
-          }
-        }
-
-        // Fetch token data for each mentioned file (parallel IPC calls)
-        const mentionedFileTokenData = new Map<string, MentionedFileInfo>();
-        const mentionedFileResults = await Promise.all(
-          Array.from(mentionedFilePaths).map(async (filePath) => {
-            try {
-              const fileInfo = await api.readMentionedFile(filePath, projectRoot);
-              return { filePath, fileInfo };
-            } catch (err) {
-              logger.error('Failed to read mentioned file:', filePath, err);
-              return { filePath, fileInfo: null };
-            }
-          })
-        );
-        if (requestGeneration !== sessionDetailFetchGeneration) {
-          return;
-        }
-        for (const { filePath, fileInfo } of mentionedFileResults) {
-          if (fileInfo) {
-            mentionedFileTokenData.set(filePath, fileInfo);
-          }
-        }
-
-        // Process Visible Context with all token data
-        // Pass validated directory token data so contextTracker can filter non-existent files
-        const phaseResult = processSessionContextWithPhases(
-          conversation.items,
-          projectRoot,
-          claudeMdTokenData,
-          mentionedFileTokenData,
-          directoryTokenData
-        );
-        contextStats = phaseResult.statsMap;
-        phaseInfo = phaseResult.phaseInfo;
       }
 
       // Update tab label if this session is open in a tab
@@ -404,16 +251,17 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
         currentState.updateTabLabel(existingTab.id, newLabel);
       }
 
+      // Phase 1 set: conversation renders immediately, stats are null (filled in Phase 2)
       set({
-        sessionDetail: detail,
+        sessionDetail: slimDetail,
         sessionDetailLoading: false,
         conversation,
         conversationLoading: false,
         visibleAIGroupId: firstAIGroupId,
         selectedAIGroup: firstAIGroup,
-        sessionClaudeMdStats: claudeMdStats,
-        sessionContextStats: contextStats,
-        sessionPhaseInfo: phaseInfo,
+        sessionClaudeMdStats: null,
+        sessionContextStats: null,
+        sessionPhaseInfo: null,
       });
 
       // Auto-expand all AI groups if the setting is enabled
@@ -425,26 +273,221 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
         }
       }
 
-      // Store per-tab session data
+      // Store per-tab session data (Phase 1 — stats null)
       if (tabId) {
         const prev = get().tabSessionData;
         set({
           tabSessionData: {
             ...prev,
             [tabId]: {
-              sessionDetail: detail,
+              sessionDetail: slimDetail,
               conversation,
               conversationLoading: false,
               sessionDetailLoading: false,
               sessionDetailError: null,
-              sessionClaudeMdStats: claudeMdStats,
-              sessionContextStats: contextStats,
-              sessionPhaseInfo: phaseInfo,
+              sessionClaudeMdStats: null,
+              sessionContextStats: null,
+              sessionPhaseInfo: null,
               visibleAIGroupId: firstAIGroupId,
               selectedAIGroup: firstAIGroup,
             },
           },
         });
+      }
+
+      // =====================================================================
+      // Phase 2: Deferred context tracking — fire-and-forget async block
+      // that computes stats and updates the store when ready.
+      // =====================================================================
+
+      if (connectionMode !== 'ssh' && conversation?.items) {
+        void (async () => {
+          try {
+            // Fetch real CLAUDE.md token data
+            let claudeMdTokenData: Record<string, ClaudeMdFileInfo> = {};
+            try {
+              claudeMdTokenData = await api.readClaudeMdFiles(projectRoot);
+              if (requestGeneration !== sessionDetailFetchGeneration) return;
+            } catch (err) {
+              logger.error('Failed to read CLAUDE.md files:', err);
+            }
+
+            const claudeMdStats = processSessionClaudeMd(
+              conversation.items,
+              projectRoot,
+              claudeMdTokenData
+            );
+
+            // Fetch real tokens for directory CLAUDE.md files
+            const directoryTokenData: Record<string, ClaudeMdFileInfo> = {};
+
+            if (claudeMdStats && claudeMdStats.size > 0) {
+              const directoryPaths = new Set<string>();
+              for (const stats of claudeMdStats.values()) {
+                for (const injection of stats.accumulatedInjections) {
+                  if (injection.source === 'directory') {
+                    directoryPaths.add(injection.path);
+                  }
+                }
+              }
+
+              if (directoryPaths.size > 0) {
+                const directoryTokens = new Map<string, number>();
+                const nonExistentPaths = new Set<string>();
+
+                const directoryResults = await batchAsync(
+                  Array.from(directoryPaths),
+                  async (fullPath) => {
+                    try {
+                      const dirPath = fullPath.replace(/[\\/]CLAUDE\.md$/, '');
+                      const fileInfo = await api.readDirectoryClaudeMd(dirPath);
+                      return { fullPath, fileInfo, error: false };
+                    } catch (err) {
+                      logger.error('Failed to read directory CLAUDE.md:', fullPath, err);
+                      return { fullPath, fileInfo: null, error: true };
+                    }
+                  },
+                  5
+                );
+                if (requestGeneration !== sessionDetailFetchGeneration) return;
+
+                for (const { fullPath, fileInfo, error } of directoryResults) {
+                  if (error || !fileInfo) {
+                    nonExistentPaths.add(fullPath);
+                  } else if (fileInfo.exists && fileInfo.estimatedTokens > 0) {
+                    directoryTokens.set(fullPath, fileInfo.estimatedTokens);
+                    directoryTokenData[fullPath] = fileInfo;
+                  } else {
+                    nonExistentPaths.add(fullPath);
+                  }
+                }
+
+                // Update stats: set real tokens and REMOVE non-existent files
+                for (const [, stats] of claudeMdStats.entries()) {
+                  stats.accumulatedInjections = stats.accumulatedInjections.filter(
+                    (inj) => inj.source !== 'directory' || !nonExistentPaths.has(inj.path)
+                  );
+                  stats.newInjections = stats.newInjections.filter(
+                    (inj) => inj.source !== 'directory' || !nonExistentPaths.has(inj.path)
+                  );
+
+                  for (const injection of stats.accumulatedInjections) {
+                    if (injection.source === 'directory' && directoryTokens.has(injection.path)) {
+                      injection.estimatedTokens = directoryTokens.get(injection.path)!;
+                    }
+                  }
+                  for (const injection of stats.newInjections) {
+                    if (injection.source === 'directory' && directoryTokens.has(injection.path)) {
+                      injection.estimatedTokens = directoryTokens.get(injection.path)!;
+                    }
+                  }
+
+                  stats.totalEstimatedTokens = stats.accumulatedInjections.reduce(
+                    (sum, inj) => sum + inj.estimatedTokens,
+                    0
+                  );
+                  stats.accumulatedCount = stats.accumulatedInjections.length;
+                  stats.newCount = stats.newInjections.length;
+                }
+              }
+            }
+
+            // Extract all mentioned file paths from user groups
+            const mentionedFilePaths = new Set<string>();
+            for (const item of conversation.items) {
+              if (item.type === 'user' && item.group.content.fileReferences) {
+                for (const ref of item.group.content.fileReferences) {
+                  const absolutePath = resolveFilePath(projectRoot, ref.path);
+                  mentionedFilePaths.add(absolutePath);
+                }
+              }
+            }
+
+            // Also collect @-mentions from isMeta:true user messages in AI responses
+            for (const item of conversation.items) {
+              if (item.type === 'ai') {
+                for (const msg of item.group.responses) {
+                  if (msg.type !== 'user') continue;
+                  let text = '';
+                  if (typeof msg.content === 'string') {
+                    text = msg.content;
+                  } else if (Array.isArray(msg.content)) {
+                    for (const block of msg.content) {
+                      if (block.type === 'text' && block.text) text += block.text;
+                    }
+                  }
+                  if (text) {
+                    for (const ref of extractFileReferences(text)) {
+                      const absolutePath = resolveFilePath(projectRoot, ref.path);
+                      mentionedFilePaths.add(absolutePath);
+                    }
+                  }
+                }
+              }
+            }
+
+            // Fetch token data for each mentioned file (throttled IPC calls)
+            const mentionedFileTokenData = new Map<string, MentionedFileInfo>();
+            const mentionedFileResults = await batchAsync(
+              Array.from(mentionedFilePaths),
+              async (filePath) => {
+                try {
+                  const fileInfo = await api.readMentionedFile(filePath, projectRoot);
+                  return { filePath, fileInfo };
+                } catch (err) {
+                  logger.error('Failed to read mentioned file:', filePath, err);
+                  return { filePath, fileInfo: null };
+                }
+              },
+              5
+            );
+            if (requestGeneration !== sessionDetailFetchGeneration) return;
+
+            for (const { filePath, fileInfo } of mentionedFileResults) {
+              if (fileInfo) {
+                mentionedFileTokenData.set(filePath, fileInfo);
+              }
+            }
+
+            // Process Visible Context with all token data
+            const phaseResult = processSessionContextWithPhases(
+              conversation.items,
+              projectRoot,
+              claudeMdTokenData,
+              mentionedFileTokenData,
+              directoryTokenData
+            );
+
+            // Phase 2 set: update only the context stats
+            if (requestGeneration !== sessionDetailFetchGeneration) return;
+            set({
+              sessionClaudeMdStats: claudeMdStats,
+              sessionContextStats: phaseResult.statsMap,
+              sessionPhaseInfo: phaseResult.phaseInfo,
+            });
+
+            // Update per-tab stats
+            if (tabId) {
+              const prev = get().tabSessionData;
+              const tabData = prev[tabId];
+              if (tabData) {
+                set({
+                  tabSessionData: {
+                    ...prev,
+                    [tabId]: {
+                      ...tabData,
+                      sessionClaudeMdStats: claudeMdStats,
+                      sessionContextStats: phaseResult.statsMap,
+                      sessionPhaseInfo: phaseResult.phaseInfo,
+                    },
+                  },
+                });
+              }
+            }
+          } catch (err) {
+            logger.error('Phase 2 context tracking error:', err);
+          }
+        })();
       }
     } catch (error) {
       logger.error('fetchSessionDetail error:', error);
@@ -521,11 +564,33 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
       if (!enhancedChunks) {
         return;
       }
-      const newConversation = transformChunksToConversation(
-        enhancedChunks,
-        detail.processes,
-        isOngoing
-      );
+
+      // ---------------------------------------------------------------
+      // Fingerprint check: skip expensive transformation when content is
+      // unchanged. Most file-watcher events are duplicates or metadata-only.
+      // ---------------------------------------------------------------
+      const lastChunk = enhancedChunks[enhancedChunks.length - 1];
+      const fingerprint = `${enhancedChunks.length}:${lastChunk?.rawMessages?.length ?? 0}:${isOngoing}`;
+      const prevFingerprint = sessionChunkFingerprint.get(refreshKey);
+      if (fingerprint === prevFingerprint) {
+        return; // Nothing changed — skip transformation
+      }
+      sessionChunkFingerprint.set(refreshKey, fingerprint);
+
+      // ---------------------------------------------------------------
+      // Early release: null out raw data from IPC before transformation
+      // to reduce peak memory (detail + enhancedChunks + newConversation).
+      // _subagents parameter is unused by the transformer.
+      // ---------------------------------------------------------------
+      const slimDetail = { ...detail, chunks: [], processes: [] };
+
+      // Use incremental update when a previous conversation exists —
+      // reuses unchanged ChatItem objects, only re-transforms the tail.
+      const prevConversation = get().conversation;
+      const newConversation =
+        prevConversation && prevConversation.items.length > 0
+          ? incrementalUpdateConversation(prevConversation, enhancedChunks, [], isOngoing)
+          : transformChunksToConversation(enhancedChunks, [], isOngoing);
 
       if (!newConversation) {
         return;
@@ -573,11 +638,11 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
 
       // Update only the data, preserve UI states
       set((state) => ({
-        sessionDetail: detail,
+        sessionDetail: slimDetail,
         conversation: newConversation,
         // Update on latest sessions state to avoid restoring stale sidebar snapshots.
         sessions: state.sessions.map((s) =>
-          s.id === sessionId ? { ...s, isOngoing: detail.session?.isOngoing ?? false } : s
+          s.id === sessionId ? { ...s, isOngoing: slimDetail.session?.isOngoing ?? false } : s
         ),
         // Preserve visible group if it still exists, otherwise keep current
         ...(visibleGroupStillExists
@@ -634,7 +699,7 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
 
           latestTabSessionData[tab.id] = {
             ...tabData,
-            sessionDetail: detail,
+            sessionDetail: slimDetail,
             conversation: newConversation,
             ...(tabGroupStillExists ? { selectedAIGroup: tabSelectedGroup } : {}),
           };

--- a/src/renderer/store/utils/batchAsync.ts
+++ b/src/renderer/store/utils/batchAsync.ts
@@ -1,0 +1,24 @@
+/**
+ * Concurrency-limited batch executor for async operations.
+ * Prevents unbounded parallel IPC calls that can exhaust the renderer heap.
+ */
+export async function batchAsync<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency = 5
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+  return results;
+}

--- a/src/renderer/types/contextInjection.ts
+++ b/src/renderer/types/contextInjection.ts
@@ -267,7 +267,11 @@ export interface NewCountsByCategory {
 export interface ContextStats {
   /** Injections that are new in THIS group */
   newInjections: ContextInjection[];
-  /** All injections accumulated up to and including this group */
+  /**
+   * All injections accumulated up to and including this group.
+   * Only populated for the last AI group in each context phase (to save memory).
+   * Intermediate groups have an empty array here.
+   */
   accumulatedInjections: ContextInjection[];
   /** Total estimated tokens from all accumulated injections */
   totalEstimatedTokens: number;
@@ -275,6 +279,8 @@ export interface ContextStats {
   tokensByCategory: TokensByCategory;
   /** Counts of new injections in this group, by category */
   newCounts: NewCountsByCategory;
+  /** Running totals of accumulated injection counts by category (always populated) */
+  accumulatedCounts: NewCountsByCategory;
   /** Which context phase this stats belongs to (1-based) */
   phaseNumber?: number;
 }

--- a/src/renderer/utils/claudeMdTracker.ts
+++ b/src/renderer/utils/claudeMdTracker.ts
@@ -477,27 +477,35 @@ interface ComputeClaudeMdStatsParams {
   userGroup: UserGroup | null;
   isFirstGroup: boolean;
   previousInjections: ClaudeMdInjection[];
+  /** Paths already seen in previous groups (threaded to avoid O(N) rebuild per group) */
+  previousPaths: Set<string>;
   projectRoot: string;
   contextTokens: number;
   tokenData?: Record<string, ClaudeMdFileInfo>;
 }
 
+interface ComputeClaudeMdStatsResult {
+  stats: ClaudeMdStats;
+  /** Updated previousPaths set — caller should thread this to the next group */
+  previousPaths: Set<string>;
+}
+
 /**
  * Compute CLAUDE.md injection statistics for an AI group.
  */
-function computeClaudeMdStats(params: ComputeClaudeMdStatsParams): ClaudeMdStats {
+function computeClaudeMdStats(params: ComputeClaudeMdStatsParams): ComputeClaudeMdStatsResult {
   const {
     aiGroup,
     userGroup,
     isFirstGroup,
     previousInjections,
+    previousPaths,
     projectRoot,
     contextTokens,
     tokenData,
   } = params;
 
   const newInjections: ClaudeMdInjection[] = [];
-  const previousPaths = new Set(previousInjections.map((inj) => inj.path));
 
   // For the first group, add global injections
   // Use "ai-N" format for firstSeenInGroup to enable turn navigation in SessionClaudeMdPanel
@@ -562,8 +570,11 @@ function computeClaudeMdStats(params: ComputeClaudeMdStatsParams): ClaudeMdStats
     }
   }
 
-  // Build accumulated injections
-  const accumulatedInjections = [...previousInjections, ...newInjections];
+  // Build accumulated injections (mutable push to avoid O(N²) spread)
+  for (const inj of newInjections) {
+    previousInjections.push(inj);
+  }
+  const accumulatedInjections = previousInjections;
 
   // Calculate totals
   const totalEstimatedTokens = accumulatedInjections.reduce(
@@ -575,12 +586,15 @@ function computeClaudeMdStats(params: ComputeClaudeMdStatsParams): ClaudeMdStats
   const percentageOfContext = contextTokens > 0 ? (totalEstimatedTokens / contextTokens) * 100 : 0;
 
   return {
-    newInjections,
-    accumulatedInjections,
-    totalEstimatedTokens,
-    percentageOfContext,
-    newCount: newInjections.length,
-    accumulatedCount: accumulatedInjections.length,
+    stats: {
+      newInjections,
+      accumulatedInjections,
+      totalEstimatedTokens,
+      percentageOfContext,
+      newCount: newInjections.length,
+      accumulatedCount: accumulatedInjections.length,
+    },
+    previousPaths,
   };
 }
 
@@ -599,6 +613,7 @@ export function processSessionClaudeMd(
 ): Map<string, ClaudeMdStats> {
   const statsMap = new Map<string, ClaudeMdStats>();
   let accumulatedInjections: ClaudeMdInjection[] = [];
+  let previousPaths = new Set<string>();
   let isFirstAiGroup = true;
   let previousUserGroup: UserGroup | null = null;
 
@@ -612,6 +627,7 @@ export function processSessionClaudeMd(
     // Handle compact items: reset accumulated state across compaction boundaries
     if (item.type === 'compact') {
       accumulatedInjections = [];
+      previousPaths = new Set<string>();
       isFirstAiGroup = true;
       previousUserGroup = null;
       continue;
@@ -626,21 +642,27 @@ export function processSessionClaudeMd(
       const contextTokens = aiGroup.tokens.input || 0;
 
       // Compute stats for this group
-      const stats = computeClaudeMdStats({
+      const result = computeClaudeMdStats({
         aiGroup,
         userGroup: previousUserGroup,
         isFirstGroup: isFirstAiGroup,
         previousInjections: accumulatedInjections,
+        previousPaths,
         projectRoot,
         contextTokens,
         tokenData,
       });
+      const stats = result.stats;
 
-      // Store stats
-      statsMap.set(aiGroup.id, stats);
+      // Store stats (snapshot accumulatedInjections so later mutations don't corrupt stored entries)
+      statsMap.set(aiGroup.id, {
+        ...stats,
+        accumulatedInjections: [...stats.accumulatedInjections],
+      });
 
       // Update accumulated state for next iteration
       accumulatedInjections = stats.accumulatedInjections;
+      previousPaths = result.previousPaths;
       isFirstAiGroup = false;
 
       // Clear the user group pairing after processing

--- a/src/renderer/utils/contextTracker.ts
+++ b/src/renderer/utils/contextTracker.ts
@@ -436,6 +436,8 @@ interface ComputeContextStatsParams {
   isFirstGroup: boolean;
   /** Accumulated injections from previous groups */
   previousInjections: ContextInjection[];
+  /** Paths already seen in previous groups (threaded to avoid O(N) rebuild per group) */
+  previousPaths: Set<string>;
   /** Project root path for resolving relative paths */
   projectRoot: string;
   /** Token data for CLAUDE.md files (global sources) */
@@ -444,6 +446,12 @@ interface ComputeContextStatsParams {
   mentionedFileTokenData?: Map<string, MentionedFileInfo>;
   /** Token data for validated directory CLAUDE.md files (keyed by full path) */
   directoryTokenData?: Record<string, ClaudeMdFileInfo>;
+}
+
+interface ComputeContextStatsResult {
+  stats: ContextStats;
+  /** Updated previousPaths set — caller should thread this to the next group */
+  previousPaths: Set<string>;
 }
 
 /**
@@ -589,7 +597,7 @@ function createDirectoryInjection(path: string, aiGroupId: string): ClaudeMdInje
  * Compute context stats for an AI group.
  * Tracks CLAUDE.md injections, mentioned files, and tool outputs.
  */
-function computeContextStats(params: ComputeContextStatsParams): ContextStats {
+function computeContextStats(params: ComputeContextStatsParams): ComputeContextStatsResult {
   const {
     aiGroup,
     userGroup,
@@ -597,6 +605,7 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
     displayItems,
     isFirstGroup,
     previousInjections,
+    previousPaths,
     projectRoot,
     claudeMdTokenData,
     mentionedFileTokenData,
@@ -604,14 +613,6 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
   } = params;
 
   const newInjections: ContextInjection[] = [];
-  const previousPaths = new Set(
-    previousInjections
-      .filter(
-        (inj): inj is ClaudeMdContextInjection | MentionedFileInjection =>
-          inj.category === 'claude-md' || inj.category === CATEGORY_MENTIONED_FILE
-      )
-      .map((inj) => inj.path)
-  );
 
   // Use "ai-N" format for firstSeenInGroup to enable turn navigation
   const turnGroupId = `ai-${aiGroup.turnIndex}`;
@@ -804,8 +805,11 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
     }
   }
 
-  // f) Build accumulated injections
-  const accumulatedInjections = [...previousInjections, ...newInjections];
+  // f) Build accumulated injections (mutable push to avoid O(N²) spread)
+  for (const inj of newInjections) {
+    previousInjections.push(inj);
+  }
+  const accumulatedInjections = previousInjections;
 
   // g) Calculate totals and category breakdowns
   const tokensByCategory: TokensByCategory = {
@@ -850,26 +854,41 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
     }
   }
 
-  // Sum tokens by category from accumulated injections
+  // Sum tokens and counts by category from accumulated injections
+  const accumulatedCounts: NewCountsByCategory = {
+    claudeMd: 0,
+    mentionedFiles: 0,
+    toolOutputs: 0,
+    thinkingText: 0,
+    taskCoordination: 0,
+    userMessages: 0,
+  };
+
   for (const injection of accumulatedInjections) {
     switch (injection.category) {
       case 'claude-md':
         tokensByCategory.claudeMd += injection.estimatedTokens;
+        accumulatedCounts.claudeMd++;
         break;
       case CATEGORY_MENTIONED_FILE:
         tokensByCategory.mentionedFiles += injection.estimatedTokens;
+        accumulatedCounts.mentionedFiles++;
         break;
       case 'tool-output':
         tokensByCategory.toolOutputs += injection.estimatedTokens;
+        accumulatedCounts.toolOutputs += injection.toolCount;
         break;
       case 'thinking-text':
         tokensByCategory.thinkingText += injection.estimatedTokens;
+        accumulatedCounts.thinkingText++;
         break;
       case 'task-coordination':
         tokensByCategory.taskCoordination += injection.estimatedTokens;
+        accumulatedCounts.taskCoordination += injection.breakdown.length;
         break;
       case 'user-message':
         tokensByCategory.userMessages += injection.estimatedTokens;
+        accumulatedCounts.userMessages++;
         break;
     }
   }
@@ -883,11 +902,15 @@ function computeContextStats(params: ComputeContextStatsParams): ContextStats {
     tokensByCategory.userMessages;
 
   return {
-    newInjections,
-    accumulatedInjections,
-    totalEstimatedTokens,
-    tokensByCategory,
-    newCounts,
+    stats: {
+      newInjections,
+      accumulatedInjections,
+      totalEstimatedTokens,
+      tokensByCategory,
+      newCounts,
+      accumulatedCounts,
+    },
+    previousPaths,
   };
 }
 
@@ -948,6 +971,7 @@ export function processSessionContextWithPhases(
 ): { statsMap: Map<string, ContextStats>; phaseInfo: ContextPhaseInfo } {
   const statsMap = new Map<string, ContextStats>();
   let accumulatedInjections: ContextInjection[] = [];
+  let previousPaths = new Set<string>();
   let isFirstAiGroup = true;
   let previousUserGroup: UserGroup | null = null;
 
@@ -972,6 +996,17 @@ export function processSessionContextWithPhases(
 
     // Handle compact items: reset accumulated state and start new phase
     if (item.type === 'compact') {
+      // Backfill accumulatedInjections for the last group in the ending phase
+      if (currentPhaseLastAIGroupId) {
+        const lastStats = statsMap.get(currentPhaseLastAIGroupId);
+        if (lastStats) {
+          statsMap.set(currentPhaseLastAIGroupId, {
+            ...lastStats,
+            accumulatedInjections: [...accumulatedInjections],
+          });
+        }
+      }
+
       // Finalize the current phase before starting a new one
       if (currentPhaseFirstAIGroupId && currentPhaseLastAIGroupId) {
         phases.push({
@@ -984,6 +1019,7 @@ export function processSessionContextWithPhases(
 
       // Reset context tracking state
       accumulatedInjections = [];
+      previousPaths = new Set<string>();
       isFirstAiGroup = true;
       previousUserGroup = null;
 
@@ -1004,18 +1040,11 @@ export function processSessionContextWithPhases(
     if (item.type === 'ai') {
       const aiGroup = item.group;
 
-      // Compute linked tools for this AI group
-      interface EnhancedAIGroupProps {
-        linkedTools?: Map<string, LinkedToolItem>;
-        displayItems?: AIGroupDisplayItem[];
-      }
-      let linkedTools = (aiGroup as AIGroup & EnhancedAIGroupProps).linkedTools;
-      if (!linkedTools || linkedTools.size === 0) {
-        linkedTools = linkToolCallsToResults(aiGroup.steps, aiGroup.responses);
-      }
+      // Compute linked tools and display items for this AI group
+      const linkedTools = linkToolCallsToResults(aiGroup.steps, aiGroup.responses);
 
-      let displayItems = (aiGroup as AIGroup & EnhancedAIGroupProps).displayItems;
-      if (!displayItems && aiGroup.steps && aiGroup.steps.length > 0) {
+      let displayItems: AIGroupDisplayItem[] | undefined;
+      if (aiGroup.steps && aiGroup.steps.length > 0) {
         const lastOutput = findLastOutput(aiGroup.steps, aiGroup.isOngoing ?? false);
         displayItems = buildDisplayItems(
           aiGroup.steps,
@@ -1026,18 +1055,20 @@ export function processSessionContextWithPhases(
       }
 
       // Compute stats for this group
-      const stats = computeContextStats({
+      const result = computeContextStats({
         aiGroup,
         userGroup: previousUserGroup,
         linkedTools,
         displayItems,
         isFirstGroup: isFirstAiGroup,
         previousInjections: accumulatedInjections,
+        previousPaths,
         projectRoot,
         claudeMdTokenData,
         mentionedFileTokenData,
         directoryTokenData,
       });
+      const stats = result.stats;
 
       // Tag with phase number
       stats.phaseNumber = currentPhaseNumber;
@@ -1057,8 +1088,12 @@ export function processSessionContextWithPhases(
         }
       }
 
-      // Store stats
-      statsMap.set(aiGroup.id, stats);
+      // Store stats WITHOUT the full accumulatedInjections array (saves O(N²) memory).
+      // Only the last group per phase gets the full snapshot (backfilled below).
+      statsMap.set(aiGroup.id, {
+        ...stats,
+        accumulatedInjections: [],
+      });
 
       // Track phase boundaries
       aiGroupPhaseMap.set(aiGroup.id, currentPhaseNumber);
@@ -1070,8 +1105,21 @@ export function processSessionContextWithPhases(
 
       // Update accumulated state for next iteration
       accumulatedInjections = stats.accumulatedInjections;
+      previousPaths = result.previousPaths;
       isFirstAiGroup = false;
       previousUserGroup = null;
+    }
+  }
+
+  // Backfill accumulatedInjections for the last group in each phase.
+  // Snapshot the current accumulatedInjections for the overall last group.
+  if (currentPhaseLastAIGroupId) {
+    const lastStats = statsMap.get(currentPhaseLastAIGroupId);
+    if (lastStats) {
+      statsMap.set(currentPhaseLastAIGroupId, {
+        ...lastStats,
+        accumulatedInjections: [...accumulatedInjections],
+      });
     }
   }
 

--- a/src/renderer/utils/groupTransformer.ts
+++ b/src/renderer/utils/groupTransformer.ts
@@ -4,6 +4,9 @@
  * This module converts chunk-based data into a flat list of ChatItems
  * (UserGroups, SystemGroups, AIGroups) for a chat-style display.
  * Each item is independent - no pairing between user and AI chunks.
+ *
+ * Also provides an incremental update path that reuses unchanged ChatItem
+ * objects to reduce allocation pressure during live-session refreshes.
  */
 
 import {
@@ -176,6 +179,169 @@ export function transformChunksToConversation(
 
   return {
     sessionId: chunks[0]?.id ?? 'unknown',
+    items,
+    totalUserGroups: userCount,
+    totalSystemGroups: systemCount,
+    totalAIGroups: aiCount,
+    totalCompactGroups: compactCount,
+  };
+}
+
+// =============================================================================
+// Incremental Update
+// =============================================================================
+
+/**
+ * Incrementally updates a conversation by reusing unchanged ChatItem objects.
+ *
+ * During live-session refreshes, only the last chunk may have streaming updates
+ * and new chunks may have been appended. Instead of re-creating ALL ChatItem
+ * objects (O(N) allocation), this function reuses the prefix of unchanged items
+ * and only transforms the tail (O(delta) allocation).
+ *
+ * Falls back to full transformation if chunk count decreased (rare edge case).
+ */
+export function incrementalUpdateConversation(
+  prevConversation: SessionConversation,
+  chunks: EnhancedChunk[],
+  _subagents: Process[],
+  isOngoing: boolean
+): SessionConversation {
+  const prevItems = prevConversation.items;
+  const newChunkCount = chunks.length;
+  const prevItemCount = prevItems.length;
+
+  // Fall back to full transform if chunks decreased or no previous items
+  if (newChunkCount < prevItemCount || prevItemCount === 0) {
+    return transformChunksToConversation(chunks, _subagents, isOngoing);
+  }
+
+  // Reuse all items except the last one (it might have streaming updates)
+  const reuseCount = prevItemCount - 1;
+  const items: ChatItem[] = prevItems.slice(0, reuseCount);
+
+  // Count type indices in reused items
+  let userCount = 0;
+  let systemCount = 0;
+  let aiCount = 0;
+  let compactCount = 0;
+  for (const item of items) {
+    switch (item.type) {
+      case 'user':
+        userCount++;
+        break;
+      case 'system':
+        systemCount++;
+        break;
+      case 'ai':
+        aiCount++;
+        break;
+      case 'compact':
+        compactCount++;
+        break;
+    }
+  }
+
+  // Clear isOngoing from the last reused AI group (it may have been set
+  // in the previous transform). Clone to avoid mutating React-referenced objects.
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (items[i].type === 'ai') {
+      const group = items[i].group as AIGroup;
+      if ((group as AIGroup & { isOngoing?: boolean }).isOngoing) {
+        items[i] = {
+          type: 'ai',
+          group: {
+            ...group,
+            isOngoing: false,
+            status: group.status === 'in_progress' ? 'complete' : group.status,
+          },
+        } as ChatItem;
+      }
+      break; // Only the last AI group could have isOngoing
+    }
+  }
+
+  // Transform only the last old chunk + any new chunks
+  for (let i = reuseCount; i < newChunkCount; i++) {
+    const chunk = chunks[i];
+    if (isEnhancedUserChunk(chunk)) {
+      items.push({
+        type: 'user',
+        group: createUserGroupFromChunk(chunk, userCount++),
+      });
+    } else if (isEnhancedSystemChunk(chunk)) {
+      items.push({
+        type: 'system',
+        group: createSystemGroup(chunk),
+      });
+      systemCount++;
+    } else if (isEnhancedAIChunk(chunk)) {
+      items.push({
+        type: 'ai',
+        group: createAIGroupFromChunk(chunk, aiCount),
+      });
+      aiCount++;
+    } else if (isEnhancedCompactChunk(chunk)) {
+      items.push({
+        type: 'compact',
+        group: createCompactGroup(chunk),
+      });
+      compactCount++;
+    }
+  }
+
+  // Post-pass: CompactGroup token deltas — clone before mutating to avoid
+  // changing objects still referenced by the previous store snapshot.
+  let phaseCounter = 1;
+  for (let i = 0; i < items.length; i++) {
+    if (items[i].type === 'compact') {
+      phaseCounter++;
+      const compactItem = items[i] as { type: 'compact'; group: CompactGroup };
+      const nextGroup: CompactGroup = {
+        ...compactItem.group,
+        startingPhaseNumber: phaseCounter,
+      };
+
+      const preAi = findLastAiBefore(items, i);
+      const postAi = findFirstAiAfter(items, i);
+      if (preAi && postAi) {
+        const pre = getLastAssistantTotalTokens(preAi);
+        const post = getFirstAssistantTotalTokens(postAi);
+        if (pre !== undefined && post !== undefined) {
+          nextGroup.tokenDelta = {
+            preCompactionTokens: pre,
+            postCompactionTokens: post,
+            delta: post - pre,
+          };
+        }
+      }
+      items[i] = { type: 'compact', group: nextGroup };
+    }
+  }
+
+  // Post-pass: isOngoing flag on last AI group — clone to preserve immutability
+  if (isOngoing && aiCount > 0) {
+    for (let i = items.length - 1; i >= 0; i--) {
+      const item = items[i];
+      if (item.type === 'ai') {
+        const currentStatus = item.group.status;
+        if (currentStatus !== 'interrupted') {
+          items[i] = {
+            type: 'ai',
+            group: {
+              ...item.group,
+              isOngoing: true,
+              status: 'in_progress',
+            },
+          } as ChatItem;
+        }
+        break;
+      }
+    }
+  }
+
+  return {
+    sessionId: prevConversation.sessionId,
     items,
     totalUserGroups: userCount,
     totalSystemGroups: systemCount,


### PR DESCRIPTION
## Summary
The renderer crashes with exitCode 133 (V8 OOM) after ~24 hours of continuous uptime. This PR addresses the root causes with memory-only optimizations (split from #114 per feedback).

### Changes

**Incremental conversation update** (`groupTransformer.ts`)
- New `incrementalUpdateConversation()` reuses unchanged ChatItem objects from the previous conversation — only re-transforms the last chunk + any new chunks
- Reduces per-refresh allocation from O(N) to O(delta)
- Post-passes clone groups before mutating to preserve store snapshot immutability

**Fingerprint-based skip** (`sessionDetailSlice.ts`)
- Stores `chunkCount:lastChunkSize:isOngoing` per session
- Skips transformation entirely when nothing changed (handles file-watcher double-fires)

**Adaptive debounce** (`store/index.ts`)
- Scales refresh interval with session size: 60s for >1000 AI groups, 30s/10s/3s for smaller thresholds, 150ms default
- Uses the **target session's** cached `totalAIGroups` (not the global conversation) so a long session in one pane doesn't affect short sessions in other panes

**Strip raw session data** (`sessionDetailSlice.ts`)
- `detail.chunks` and `detail.processes` nulled after transformation (`slimDetail`)
- Export re-fetches full detail on demand from IPC

**O(N²) → O(N) fixes** (`contextTracker.ts`, `claudeMdTracker.ts`)
- Replace `[...prev, ...new]` spread accumulation with mutable push loop
- Thread `previousPaths: Set<string>` to avoid redundant set recreation
- Precomputed `accumulatedCounts` on `ContextStats` replaces per-render array filtering

**Phase 1/Phase 2 split** (`sessionDetailSlice.ts`)
- Phase 1: push conversation to store immediately for rendering
- Phase 2: fire-and-forget async context stats computation

**Other**
- `batchAsync` utility for concurrency-limited IPC calls
- Lower `VIRTUALIZATION_THRESHOLD` 120 → 30 (virtualize sooner so fewer DOM nodes exist for large sessions — 30 is still large enough for casual sessions to render inline, but kicks in earlier for the 100+ item sessions that stress memory)
- Dynamic renderer heap: `50% of system RAM, clamped to [2 GB, 4 GB]` — adapts to the machine instead of a hardcoded value

### Addressing review feedback from #114
- **8GB heap concern**: replaced with dynamic limit based on `os.totalmem()` (2–4 GB range)
- **`'completed'` → `'complete'`**: fixed to match `AIGroupStatus` type
- **Post-pass mutation**: CompactGroup and isOngoing post-passes now clone before mutating
- **Adaptive debounce scope**: now uses per-session `totalAIGroups` instead of global conversation
- **Scope**: removed crash logging and task notification rendering (separate PRs)

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] All 653 tests pass
- [ ] Manual: run a long session (1h+), verify no crash and adaptive debounce scales
- [ ] Manual: open multiple tabs with different session sizes, verify each gets its own debounce interval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Export now fetches current session data and shows an “Exporting…” state during downloads.

* **Performance Improvements**
  * Renderer memory adjusted dynamically for better stability.
  * Chat list virtualization threshold reduced for smoother rendering on shorter conversations.
  * Session refresh timing adapted based on session size for timely updates.
  * Session loading made faster via incremental updates and staged detail publishing.
  * Token/context stats and file reads optimized for lower memory and controlled concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->