### PR TITLE
feat: render task notifications as styled cards

### DIFF
--- a/src/renderer/components/chat/UserChatGroup.tsx
+++ b/src/renderer/components/chat/UserChatGroup.tsx
@@ -4,9 +4,10 @@ import ReactMarkdown, { type Components } from 'react-markdown';
 import { api } from '@renderer/api';
 import { useTabUI } from '@renderer/hooks/useTabUI';
 import { useStore } from '@renderer/store';
+import { parseTaskNotifications } from '@shared/utils/contentSanitizer';
 import { createLogger } from '@shared/utils/logger';
 import { format } from 'date-fns';
-import { User } from 'lucide-react';
+import { CheckCircle, Circle, FileText, User, XCircle } from 'lucide-react';
 import remarkGfm from 'remark-gfm';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -345,6 +346,20 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
   const textContent = content.rawText ?? content.text ?? '';
   const isLongContent = textContent.length > 500;
 
+  // Parse task notifications from the original message content (before sanitization)
+  const taskNotifications = useMemo(() => {
+    const raw =
+      typeof userGroup.message.content === 'string'
+        ? userGroup.message.content
+        : Array.isArray(userGroup.message.content)
+          ? userGroup.message.content
+              .filter((b): b is { type: 'text'; text: string } => b.type === 'text' && 'text' in b)
+              .map((b) => b.text)
+              .join('')
+          : '';
+    return parseTaskNotifications(raw);
+  }, [userGroup.message.content]);
+
   // Extract @path mentions from text
   const pathMentions = useMemo(() => {
     if (!textContent) return [];
@@ -461,6 +476,60 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
             )}
           </div>
         )}
+
+        {/* Task notification cards */}
+        {taskNotifications.length > 0 &&
+          taskNotifications.map((notif) => {
+            const isCompleted = notif.status === 'completed';
+            const isFailed = notif.status === 'failed' || notif.status === 'error';
+            const StatusIcon = isFailed ? XCircle : isCompleted ? CheckCircle : Circle;
+            const statusColor = isFailed
+              ? 'var(--error-highlight-text, #ef4444)'
+              : isCompleted
+                ? 'var(--badge-success-text, #22c55e)'
+                : 'var(--color-text-muted)';
+
+            // Extract quoted command name from summary (e.g., 'Background command "Run foo" completed')
+            const cmdMatch = /"([^"]+)"/.exec(notif.summary);
+            const cmdName = cmdMatch?.[1] ?? notif.summary;
+            // Extract exit code
+            const exitMatch = /\(exit code (\d+)\)/.exec(notif.summary);
+            const exitCode = exitMatch?.[1];
+
+            return (
+              <div
+                key={notif.taskId}
+                className="flex items-start gap-2.5 rounded-lg px-3 py-2"
+                style={{
+                  backgroundColor: 'var(--card-bg)',
+                  border: '1px solid var(--card-border)',
+                }}
+              >
+                <StatusIcon
+                  className="mt-0.5 size-3.5 shrink-0"
+                  style={{ color: statusColor }}
+                />
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <div
+                    className="text-xs font-medium leading-snug"
+                    style={{ color: 'var(--color-text-secondary)' }}
+                  >
+                    {cmdName}
+                  </div>
+                  <div className="flex items-center gap-2 text-[10px]" style={{ color: 'var(--color-text-muted)' }}>
+                    <span className="capitalize">{notif.status}</span>
+                    {exitCode != null && <span>exit {exitCode}</span>}
+                    {notif.outputFile && (
+                      <span className="flex items-center gap-0.5 truncate">
+                        <FileText className="size-2.5" />
+                        <span className="truncate">{notif.outputFile.split('/').pop()}</span>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
 
         {/* Images indicator */}
         {hasImages && (

--- a/src/shared/utils/contentSanitizer.ts
+++ b/src/shared/utils/contentSanitizer.ts
@@ -19,7 +19,15 @@
 const NOISE_TAG_PATTERNS = [
   /<local-command-caveat>[\s\S]*?<\/local-command-caveat>/gi,
   /<system-reminder>[\s\S]*?<\/system-reminder>/gi,
+  /<task-notification>[\s\S]*?<\/task-notification>/gi,
 ];
+
+/**
+ * Pattern to match the trailing "Read the output file to retrieve the result: /path"
+ * instruction that follows task notifications.
+ */
+const TASK_OUTPUT_INSTRUCTION_PATTERN =
+  / ?Read the output file to retrieve the result: [^\s]+/g;
 
 /**
  * Extract content from <local-command-stdout> tags.
@@ -110,6 +118,9 @@ export function sanitizeDisplayContent(content: string): string {
     .replace(/<command-message>[\s\S]*?<\/command-message>/gi, '')
     .replace(/<command-args>[\s\S]*?<\/command-args>/gi, '');
 
+  // Remove trailing "Read the output file..." instructions from task notifications
+  sanitized = sanitized.replace(TASK_OUTPUT_INSTRUCTION_PATTERN, '');
+
   return sanitized.trim();
 }
 
@@ -148,4 +159,40 @@ export function extractSlashInfo(content: string): SlashInfo | null {
     message: messageMatch?.[1]?.trim() ?? undefined,
     args: argsMatch?.[1]?.trim() ?? undefined,
   };
+}
+
+// =============================================================================
+// Task Notification Parsing
+// =============================================================================
+
+/**
+ * Parsed task notification from Claude Code's background task system.
+ */
+export interface TaskNotification {
+  taskId: string;
+  status: string;
+  summary: string;
+  outputFile: string;
+}
+
+/**
+ * Extract task notifications from raw message content.
+ * These are XML blocks injected by Claude Code when background tasks complete.
+ */
+export function parseTaskNotifications(content: string): TaskNotification[] {
+  const notifications: TaskNotification[] = [];
+  const pattern = /<task-notification>([\s\S]*?)<\/task-notification>/gi;
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const block = match[1];
+    notifications.push({
+      taskId: /<task-id>([^<]*)<\/task-id>/.exec(block)?.[1] ?? '',
+      status: /<status>([^<]*)<\/status>/.exec(block)?.[1] ?? '',
+      summary: /<summary>([\s\S]*?)<\/summary>/.exec(block)?.[1]?.trim() ?? '',
+      outputFile: /<output-file>([^<]*)<\/output-file>/.exec(block)?.[1] ?? '',
+    });
+  }
+
+  return notifications;
 }


### PR DESCRIPTION
## Summary
Parse `<task-notification>` XML blocks from user messages and render them as compact styled cards instead of raw XML.

Closes #121

### Before
Raw XML displayed verbatim in user message bubbles — confusing and noisy.

### After
Compact cards showing: status icon (green check / red X), command name, exit code, and output filename.

### Changes
- **`contentSanitizer.ts`**: Add `parseTaskNotifications()` parser + strip `<task-notification>` tags and trailing "Read the output file..." instructions from display text
- **`UserChatGroup.tsx`**: Parse task notifications from original message content, render as styled cards below the user message bubble

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] All 653 tests pass
- [ ] Manual: open a session with background tasks — notifications render as cards instead of raw XML
- [ ] Manual: session with no task notifications — no change in rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task notifications now parse and display in chat with visual status indicators (success, pending, failure)
  * Shows command names, exit codes, and optional output file information for each task
  * Status-based color coding and icons provide quick visual feedback on task completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->