### PR TITLE
feat: add tab rename and fix sidebar collapse layout

### DIFF
--- a/src/renderer/components/layout/SortableTab.tsx
+++ b/src/renderer/components/layout/SortableTab.tsx
@@ -3,7 +3,7 @@
  * Wraps useSortable from @dnd-kit for tab reordering and cross-pane movement.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -18,6 +18,9 @@ interface SortableTabProps {
   paneId: string;
   isActive: boolean;
   isSelected: boolean;
+  isRenameRequested?: boolean;
+  onRenameComplete?: () => void;
+  onRequestRename?: (tabId: string) => void;
   onTabClick: (tabId: string, e: React.MouseEvent) => void;
   onMouseDown: (tabId: string, e: React.MouseEvent) => void;
   onContextMenu: (tabId: string, e: React.MouseEvent) => void;
@@ -37,6 +40,9 @@ export const SortableTab = ({
   paneId,
   isActive,
   isSelected,
+  isRenameRequested,
+  onRenameComplete,
+  onRequestRename,
   onTabClick,
   onMouseDown,
   onContextMenu,
@@ -44,6 +50,34 @@ export const SortableTab = ({
   setRef,
 }: SortableTabProps): React.JSX.Element => {
   const [isHovered, setIsHovered] = useState(false);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const updateTabLabel = useStore((s) => s.updateTabLabel);
+
+  // Rename is driven by parent via isRenameRequested prop (context menu)
+  // or by double-click (sets renamingTabId in parent via onRenameComplete callback)
+  const isRenaming = isRenameRequested ?? false;
+
+  const commitRename = useCallback(() => {
+    const trimmed = renameInputRef.current?.value.trim() ?? '';
+    if (trimmed && trimmed !== tab.label) {
+      updateTabLabel(tab.id, trimmed);
+    }
+    onRenameComplete?.();
+  }, [tab.label, tab.id, updateTabLabel, onRenameComplete]);
+
+  const cancelRename = useCallback(() => {
+    onRenameComplete?.();
+  }, [onRenameComplete]);
+
+  // Auto-focus input when entering rename mode
+  useEffect(() => {
+    if (isRenaming && renameInputRef.current) {
+      renameInputRef.current.value = tab.label;
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [isRenaming, tab.label]);
 
   const isPinned = useStore(
     useShallow((s) =>
@@ -120,7 +154,46 @@ export const SortableTab = ({
           <Pin className="size-3 shrink-0 text-blue-400" />
         </span>
       )}
-      <span className="truncate text-sm">{tab.label}</span>
+      {isRenaming ? (
+        <input
+          ref={renameInputRef}
+          type="text"
+          defaultValue={tab.label}
+          onBlur={commitRename}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commitRename();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancelRename();
+            }
+            e.stopPropagation();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          className="w-full min-w-0 truncate rounded px-0.5 text-sm outline-none"
+          style={{
+            background: 'var(--color-surface)',
+            color: 'var(--color-text)',
+            border: '1px solid var(--color-border-emphasis)',
+          }}
+          maxLength={50}
+        />
+      ) : (
+        <span
+          className="truncate text-sm"
+          role="textbox"
+          tabIndex={-1}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            onRequestRename?.(tab.id);
+          }}
+        >
+          {tab.label}
+        </span>
+      )}
       <button
         className="flex size-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100"
         style={{ backgroundColor: 'transparent' }}

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -104,6 +104,7 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; tabId: string } | null>(
     null
   );
+  const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
 
   // Track last clicked tab for Shift range selection
   const lastClickedTabIdRef = useRef<string | null>(null);
@@ -260,9 +261,11 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
         {
           height: `${HEADER_ROW1_HEIGHT}px`,
           paddingLeft:
-            sidebarCollapsed && isLeftmostPane
+            sidebarCollapsed && isLeftmostPane && navigator.userAgent.includes('Macintosh')
               ? 'var(--macos-traffic-light-padding-left, 72px)'
-              : '8px',
+              : sidebarCollapsed && isLeftmostPane
+                ? '4px'
+                : '8px',
           WebkitAppRegion: isElectronMode() && isLeftmostPane ? 'drag' : undefined,
           backgroundColor: 'var(--color-surface)',
           borderBottom: '1px solid var(--color-border)',
@@ -315,6 +318,9 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
               paneId={paneId}
               isActive={tab.id === activeTabId}
               isSelected={selectedSet.has(tab.id)}
+              isRenameRequested={renamingTabId === tab.id}
+              onRenameComplete={() => setRenamingTabId(null)}
+              onRequestRename={(id) => setRenamingTabId(id)}
               onTabClick={handleTabClick}
               onMouseDown={handleMouseDown}
               onContextMenu={handleContextMenu}
@@ -429,6 +435,7 @@ export const TabBar = ({ paneId }: TabBarProps): React.JSX.Element => {
               ? () => toggleHideSession(contextMenuTab.sessionId!)
               : undefined
           }
+          onRename={() => setRenamingTabId(contextMenuTabId)}
         />
       )}
     </div>

--- a/src/renderer/components/layout/TabContextMenu.tsx
+++ b/src/renderer/components/layout/TabContextMenu.tsx
@@ -33,6 +33,8 @@ interface TabContextMenuProps {
   isHidden?: boolean;
   /** Callback to toggle hide state */
   onToggleHide?: () => void;
+  /** Callback to rename the tab */
+  onRename?: () => void;
 }
 
 export const TabContextMenu = ({
@@ -52,6 +54,7 @@ export const TabContextMenu = ({
   onTogglePin,
   isHidden,
   onToggleHide,
+  onRename,
 }: TabContextMenuProps): React.JSX.Element => {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -127,6 +130,12 @@ export const TabContextMenu = ({
           label={isHidden ? 'Unhide from Sidebar' : 'Hide from Sidebar'}
           onClick={handleClick(onToggleHide)}
         />
+      )}
+      {onRename && (
+        <>
+          <div className="mx-2 my-1 border-t" style={{ borderColor: 'var(--color-border)' }} />
+          <MenuItem label="Rename Tab" onClick={handleClick(onRename)} />
+        </>
       )}
       <div className="mx-2 my-1 border-t" style={{ borderColor: 'var(--color-border)' }} />
       <MenuItem label="Close All Tabs" shortcut={formatShortcut('W', { shift: true })} onClick={handleClick(onCloseAllTabs)} />


### PR DESCRIPTION
## Summary
Two tab bar improvements:

- **Tab rename**: Double-click a tab label to rename it inline (Enter to confirm, Escape to cancel). Also available via right-click context menu → "Rename Tab". Uses the existing `updateTabLabel()` store action.
- **Sidebar collapse layout**: On Linux/Windows, collapsing the sidebar no longer wastes 72px of left padding (reserved for macOS traffic lights). The expand button is now flush-left with 4px padding. macOS retains the traffic light padding via `navigator.userAgent` check.

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] All 653 tests pass
- [ ] Manual: double-click a tab label → inline input appears, rename and press Enter
- [ ] Manual: right-click tab → "Rename Tab" → same inline input
- [ ] Manual: press Escape during rename → cancels without saving
- [ ] Manual: collapse sidebar on Linux → expand button is flush-left, more tab space available
- [ ] Manual: collapse sidebar on macOS → traffic light padding preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tab renaming is now available—double-click a tab label or select "Rename Tab" from the context menu to rename tabs. Press Enter to confirm or Escape to cancel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->