### PR TITLE
fix: compute real message count in light metadata path

### DIFF
--- a/src/main/services/discovery/ProjectScanner.ts
+++ b/src/main/services/discovery/ProjectScanner.ts
@@ -26,11 +26,7 @@ import {
   type SessionsByIdsOptions,
   type SessionsPaginationOptions,
 } from '@main/types';
-import {
-  analyzeSessionFileMetadata,
-  extractCwd,
-  extractFirstUserMessagePreview,
-} from '@main/utils/jsonl';
+import { analyzeSessionFileMetadata, extractCwd } from '@main/utils/jsonl';
 import {
   buildSessionPath,
   buildSubagentsPath,
@@ -75,10 +71,6 @@ export class ProjectScanner {
       size: number;
       metadata: Awaited<ReturnType<typeof analyzeSessionFileMetadata>>;
     }
-  >();
-  private readonly sessionPreviewCache = new Map<
-    string,
-    { mtimeMs: number; size: number; preview: { text: string; timestamp: string } | null }
   >();
 
   /** Cached project list for search — avoids re-scanning disk on every query */
@@ -800,20 +792,32 @@ export class ProjectScanner {
     const effectiveMtime = prefetchedMtimeMs ?? stats?.mtimeMs ?? Date.now();
     const effectiveSize = prefetchedSize ?? stats?.size ?? -1;
     const birthtimeMs = prefetchedBirthtimeMs ?? stats?.birthtimeMs ?? effectiveMtime;
-    const cachedPreview = this.sessionPreviewCache.get(filePath);
-    const preview =
-      cachedPreview?.mtimeMs === effectiveMtime && cachedPreview.size === effectiveSize
-        ? cachedPreview.preview
-        : await this.extractLightPreviewWithRetry(filePath);
-    if (cachedPreview?.mtimeMs !== effectiveMtime || cachedPreview.size !== effectiveSize) {
-      this.sessionPreviewCache.set(filePath, {
-        mtimeMs: effectiveMtime,
-        size: effectiveSize,
-        preview,
-      });
+    let metadata: Awaited<ReturnType<typeof analyzeSessionFileMetadata>>;
+    const cachedMetadata = this.sessionMetadataCache.get(filePath);
+    if (cachedMetadata?.mtimeMs === effectiveMtime && cachedMetadata.size === effectiveSize) {
+      metadata = cachedMetadata.metadata;
+    } else {
+      try {
+        metadata = await analyzeSessionFileMetadata(filePath, this.fsProvider);
+        this.sessionMetadataCache.set(filePath, {
+          mtimeMs: effectiveMtime,
+          size: effectiveSize,
+          metadata,
+        });
+      } catch (error) {
+        logger.debug(`Failed to analyze session metadata for ${filePath}:`, error);
+        metadata = {
+          firstUserMessage: null,
+          messageCount: 0,
+          isOngoing: false,
+          gitBranch: null,
+          hasDisplayableContent: false,
+        };
+      }
     }
+
     const metadataLevel: SessionMetadataLevel = 'light';
-    const previewTimestampMs = this.parseTimestampMs(preview?.timestamp);
+    const previewTimestampMs = this.parseTimestampMs(metadata.firstUserMessage?.timestamp);
     const createdAt =
       previewTimestampMs !== null && Number.isFinite(previewTimestampMs)
         ? previewTimestampMs
@@ -824,10 +828,10 @@ export class ProjectScanner {
       projectId,
       projectPath,
       createdAt: Math.floor(createdAt),
-      firstMessage: preview?.text,
-      messageTimestamp: preview?.timestamp,
+      firstMessage: metadata.firstUserMessage?.text,
+      messageTimestamp: metadata.firstUserMessage?.timestamp,
       hasSubagents: false,
-      messageCount: 0,
+      messageCount: metadata.messageCount,
       metadataLevel,
     };
   }
@@ -1212,31 +1216,6 @@ export class ProjectScanner {
     }
 
     return results;
-  }
-
-  private async extractLightPreviewWithRetry(
-    filePath: string
-  ): Promise<{ text: string; timestamp: string } | null> {
-    const maxAttempts = this.fsProvider.type === 'ssh' ? 3 : 1;
-    let lastError: unknown;
-
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        return await extractFirstUserMessagePreview(filePath, this.fsProvider);
-      } catch (error) {
-        lastError = error;
-        if (attempt < maxAttempts && this.isTransientFsError(error)) {
-          await this.sleep(50 * attempt);
-          continue;
-        }
-        break;
-      }
-    }
-
-    if (lastError) {
-      logger.debug(`Failed to extract light preview for ${filePath}:`, lastError);
-    }
-    return null;
   }
 
   private getErrorCode(error: unknown): string {


### PR DESCRIPTION
## Summary

- **Root cause**: `buildLightSessionMetadata()` hardcoded `messageCount: 0`, but all sidebar fetch paths (`fetchSessionsInitial`, `fetchSessionsMore`, `refreshSessionsInPlace`, `loadPinnedSessions`) request `metadataLevel: 'light'` — so every session always displayed zero messages.
- **Fix**: Call `analyzeSessionFileMetadata()` with the existing `sessionMetadataCache` in the light path, replacing the hardcoded `0` with the real count.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (1 pre-existing warning in `pathDecoder.ts`, unrelated)
- [x] `pnpm test` — 653/653 tests pass
- [x] `pnpm build` — succeeds
- [ ] Manual: open app, verify sidebar shows non-zero message counts for sessions with activity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session listings now reliably show the correct first message, accurate timestamps, and proper message counts; failures to parse metadata now fall back safely instead of producing null or stale previews.

* **Performance**
  * Improved metadata caching and retrieval to reduce repeated work and make session lists more consistent and faster to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->