### PR TITLE
fix: sessions not loading on project navigation without restart

### DIFF
--- a/src/main/services/discovery/ProjectScanner.ts
+++ b/src/main/services/discovery/ProjectScanner.ts
@@ -1050,6 +1050,26 @@ export class ProjectScanner {
   }
 
   /**
+   * Invalidate internal caches for a project.
+   * Called by FileWatcher when session files change so stale cache entries
+   * (e.g. sessions previously flagged as empty) are re-evaluated.
+   */
+  invalidateCachesForProject(projectId: string): void {
+    // projectId is URL-encoded; the cache keys are absolute file paths containing the decoded dir
+    const decoded = decodeURIComponent(projectId);
+    const prefix = path.join(this.projectsDir, decoded);
+    for (const key of this.contentPresenceCache.keys()) {
+      if (key.startsWith(prefix)) this.contentPresenceCache.delete(key);
+    }
+    for (const key of this.sessionMetadataCache.keys()) {
+      if (key.startsWith(prefix)) this.sessionMetadataCache.delete(key);
+    }
+    for (const key of this.sessionPreviewCache.keys()) {
+      if (key.startsWith(prefix)) this.sessionPreviewCache.delete(key);
+    }
+  }
+
+  /**
    * Checks if the projects directory exists.
    */
   async projectsDirExists(): Promise<boolean> {

--- a/src/main/services/infrastructure/FileWatcher.ts
+++ b/src/main/services/infrastructure/FileWatcher.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { projectPathResolver } from '../discovery/ProjectPathResolver';
+import { type ProjectScanner } from '../discovery/ProjectScanner';
 import { errorDetector } from '../error/ErrorDetector';
 
 import { ConfigManager } from './ConfigManager';
@@ -60,6 +61,7 @@ export class FileWatcher extends EventEmitter {
   private dataCache: DataCache;
   private fsProvider: FileSystemProvider;
   private notificationManager: NotificationManager | null = null;
+  private projectScanner: ProjectScanner | null = null;
   private isWatching: boolean = false;
   private debounceTimers = new Map<string, NodeJS.Timeout>();
   /** Track last processed line count per file for incremental error detection */
@@ -109,6 +111,13 @@ export class FileWatcher extends EventEmitter {
   }
 
   /**
+   * Sets the ProjectScanner for cache invalidation on file changes.
+   */
+  setProjectScanner(scanner: ProjectScanner): void {
+    this.projectScanner = scanner;
+  }
+
+  /**
    * Sets the filesystem provider. Used when switching between local and SSH modes.
    */
   setFileSystemProvider(provider: FileSystemProvider): void {
@@ -139,6 +148,9 @@ export class FileWatcher extends EventEmitter {
     } else {
       this.ensureWatchers();
     }
+    this.seedActiveSessionFiles().catch((err) => {
+      logger.error('Error seeding active session files:', err);
+    });
     this.startCatchUpTimer();
   }
 
@@ -535,6 +547,7 @@ export class FileWatcher extends EventEmitter {
     if (sessionId) {
       // Invalidate cache
       this.dataCache.invalidateSession(projectId, sessionId);
+      this.projectScanner?.invalidateCachesForProject(projectId);
       projectPathResolver.invalidateProject(projectId);
       if (changeType === 'unlink') {
         this.clearErrorTracking(fullPath);
@@ -806,6 +819,63 @@ export class FileWatcher extends EventEmitter {
 
     this.emit('todo-change', event);
     logger.info(`FileWatcher: ${changeType} todo - ${filename}`);
+  }
+
+  // ===========================================================================
+  // Active Session Seeding
+  // ===========================================================================
+
+  /**
+   * Seeds activeSessionFiles with recently modified .jsonl files so the
+   * catch-up scan can detect growth in sessions that were already active
+   * before the FileWatcher started.
+   */
+  private async seedActiveSessionFiles(): Promise<void> {
+    const now = Date.now();
+    try {
+      if (!(await this.fsProvider.exists(this.projectsPath))) {
+        return;
+      }
+
+      const projectDirs = await this.fsProvider.readdir(this.projectsPath);
+      for (const dir of projectDirs) {
+        if (!dir.isDirectory()) continue;
+
+        const projectPath = path.join(this.projectsPath, dir.name);
+        let entries: FsDirent[];
+        try {
+          entries = await this.fsProvider.readdir(projectPath);
+        } catch {
+          continue;
+        }
+
+        for (const entry of entries) {
+          if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+
+          const fullPath = path.join(projectPath, entry.name);
+          try {
+            const stats = await this.fsProvider.stat(fullPath);
+            if (now - stats.mtimeMs <= CATCH_UP_MAX_AGE_MS) {
+              const sessionId = path.basename(entry.name, '.jsonl');
+              this.activeSessionFiles.set(fullPath, {
+                projectId: dir.name,
+                sessionId,
+              });
+            }
+          } catch {
+            continue;
+          }
+        }
+      }
+
+      if (this.activeSessionFiles.size > 0) {
+        logger.info(
+          `FileWatcher: Seeded ${this.activeSessionFiles.size} active session files`
+        );
+      }
+    } catch (err) {
+      logger.error('Error seeding active session files:', err);
+    }
   }
 
   // ===========================================================================

--- a/src/main/services/infrastructure/ServiceContext.ts
+++ b/src/main/services/infrastructure/ServiceContext.ts
@@ -114,6 +114,7 @@ export class ServiceContext {
       config.todosDir,
       config.fsProvider
     );
+    this.fileWatcher.setProjectScanner(this.projectScanner);
 
     logger.info(`ServiceContext created: ${config.id}`);
   }

--- a/src/renderer/store/slices/projectSlice.ts
+++ b/src/renderer/store/slices/projectSlice.ts
@@ -84,6 +84,8 @@ export const createProjectSlice: StateCreator<AppState, [], [], ProjectSlice> = 
         sessionContextStats: null,
         sessionDetailError: null,
       });
+      // Invalidate stale cache so fetchSessionsInitial() overwrites with fresh data
+      get()._sessionCache.delete(id);
     } else {
       set({
         selectedProjectId: id,


### PR DESCRIPTION
## Summary
Sessions don't appear when navigating to a project until the app is restarted. Three root causes fixed:

1. **Renderer `_sessionCache` stale hit**: `selectProject()` returns cached empty sessions from a previous visit. Fixed by clearing the cache entry after showing cached data so `fetchSessionsInitial()` always overwrites with fresh backend data.

2. **No external cache invalidation on ProjectScanner**: `contentPresenceCache`, `sessionMetadataCache`, `sessionPreviewCache` are private Maps with no invalidation API. Added `invalidateCachesForProject(projectId)` and wired it into `FileWatcher.processProjectsChange()`.

3. **`activeSessionFiles` never seeded at startup**: Sessions existing at app startup aren't added to `activeSessionFiles`, so the catch-up timer never checks them. Added `seedActiveSessionFiles()` that scans recent `.jsonl` files (last hour) on startup.

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] All 653 tests pass
- [ ] Manual: start app, create a new Claude Code session, navigate to the project — sessions should appear immediately
- [ ] Manual: verify existing session pagination still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session data automatically refreshes when switching between projects, ensuring you always see current information
  * Application now detects previously active sessions on startup for quicker initialization

* **Bug Fixes**
  * Enhanced synchronization of session data with file system changes to prevent serving stale information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->