### PR TITLE
fix: open links in system browser instead of Electron window

### DIFF
--- a/src/renderer/components/chat/UserChatGroup.tsx
+++ b/src/renderer/components/chat/UserChatGroup.tsx
@@ -171,10 +171,14 @@ function createUserMarkdownComponents(
     a: ({ href, children }) => (
       <a
         href={href}
-        className="no-underline hover:underline"
+        className="cursor-pointer no-underline hover:underline"
         style={{ color: 'var(--chat-user-tag-text)' }}
-        target="_blank"
-        rel="noopener noreferrer"
+        onClick={(e) => {
+          e.preventDefault();
+          if (href) {
+            void api.openExternal(href);
+          }
+        }}
       >
         {children}
       </a>

--- a/src/renderer/components/chat/markdownComponents.tsx
+++ b/src/renderer/components/chat/markdownComponents.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { api } from '@renderer/api';
 import { CopyButton } from '@renderer/components/common/CopyButton';
 import { PROSE_BODY } from '@renderer/constants/cssVariables';
 
@@ -78,14 +79,18 @@ export function createMarkdownComponents(searchCtx: SearchContext | null): Compo
       </p>
     ),
 
-    // Links — inline element, no hl(); parent block element's hl() descends here
+    // Links — open in system browser via IPC, not in Electron window
     a: ({ href, children }) => (
       <a
         href={href}
-        className="no-underline hover:underline"
+        className="cursor-pointer no-underline hover:underline"
         style={{ color: 'var(--prose-link)' }}
-        target="_blank"
-        rel="noopener noreferrer"
+        onClick={(e) => {
+          e.preventDefault();
+          if (href) {
+            void api.openExternal(href);
+          }
+        }}
       >
         {children}
       </a>


### PR DESCRIPTION
## Summary
Links in markdown output and user messages used `target="_blank"` which doesn't open the system browser in Electron — on Linux it can open a text editor instead.

Replaced with `e.preventDefault()` + `api.openExternal(href)` which routes through the existing `shell:openExternal` IPC handler (validates URL schemes, calls `shell.openExternal()`).

### Files changed
- `markdownComponents.tsx` — used by LastOutputDisplay, CompactBoundary, UpdateDialog
- `UserChatGroup.tsx` — user message bubble links

Note: `MarkdownViewer.tsx` already used `api.openExternal()` correctly — only these two files had `target="_blank"`.

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] All 653 tests pass
- [ ] Manual: click a URL in AI output → opens in system default browser
- [ ] Manual: click a URL in user message → opens in system default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - External links in chat now open via the app's controlled link handler instead of the browser's default new-tab behavior, ensuring consistent and reliable link opening.

* **Style**
  - Link elements in chat received cursor-pointer styling for clearer interactive affordance and improved user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->