### PR TITLE
fix: show copy button only on code blocks, not entire text output

### DIFF
--- a/src/renderer/components/chat/LastOutputDisplay.tsx
+++ b/src/renderer/components/chat/LastOutputDisplay.tsx
@@ -88,7 +88,7 @@ export const LastOutputDisplay = ({
           border: '1px solid var(--code-border)',
         }}
       >
-        <CopyButton text={textContent} />
+        {/* Copy buttons are on individual code blocks via markdownComponents */}
 
         {/* Content - scrollable */}
         <div className="max-h-96 overflow-y-auto px-4 py-3" data-search-content>

--- a/src/renderer/components/chat/items/TextItem.tsx
+++ b/src/renderer/components/chat/items/TextItem.tsx
@@ -50,7 +50,7 @@ export const TextItem: React.FC<TextItemProps> = React.memo(function TextItem({
       highlightStyle={highlightStyle}
       notificationDotColor={notificationDotColor}
     >
-      <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable />
+      <MarkdownViewer content={fullContent} maxHeight="max-h-96" />
     </BaseItem>
   );
 });

--- a/src/renderer/components/chat/markdownComponents.tsx
+++ b/src/renderer/components/chat/markdownComponents.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { CopyButton } from '@renderer/components/common/CopyButton';
 import { PROSE_BODY } from '@renderer/constants/cssVariables';
 
 import { highlightSearchInChildren, type SearchContext } from './searchHighlightUtils';
@@ -138,19 +139,34 @@ export function createMarkdownComponents(searchCtx: SearchContext | null): Compo
       );
     },
 
-    // Code blocks
-    pre: ({ children }) => (
-      <pre
-        className="my-3 overflow-x-auto rounded-lg p-3 font-mono text-xs leading-relaxed"
-        style={{
-          backgroundColor: 'var(--prose-pre-bg)',
-          border: '1px solid var(--prose-pre-border)',
-          color: 'var(--color-text)',
-        }}
-      >
-        {children}
-      </pre>
-    ),
+    // Code blocks — with copy button
+    pre: ({ children }) => {
+      // Extract text from nested <code> children for the copy button
+      const extractText = (node: React.ReactNode): string => {
+        if (typeof node === 'string') return node;
+        if (Array.isArray(node)) return node.map(extractText).join('');
+        if (React.isValidElement(node) && node.props) {
+          const props = node.props as { children?: React.ReactNode };
+          return extractText(props.children);
+        }
+        return '';
+      };
+      const codeText = extractText(children).trim();
+
+      return (
+        <pre
+          className="group relative my-3 overflow-x-auto rounded-lg p-3 font-mono text-xs leading-relaxed"
+          style={{
+            backgroundColor: 'var(--prose-pre-bg)',
+            border: '1px solid var(--prose-pre-border)',
+            color: 'var(--color-text)',
+          }}
+        >
+          {codeText && <CopyButton text={codeText} />}
+          {children}
+        </pre>
+      );
+    },
 
     // Blockquotes
     blockquote: ({ children }) => (


### PR DESCRIPTION
## Summary
The copy button appeared on the entire text output container, making it imprecise. For example, hovering over "What GPU do you have? Let me check:" showed a copy button, but the user actually wanted to copy `lspci | grep -i vga` from the code block below it.

- **Add** `CopyButton` to `pre` (fenced code blocks) in `markdownComponents.tsx` with text extraction from nested `<code>` children
- **Remove** `CopyButton` from `LastOutputDisplay` text output container
- **Remove** `copyable` prop from `TextItem`'s `MarkdownViewer`

Now copy buttons only appear on fenced code blocks where they're useful.

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint:fix` — no lint errors
- [x] All 653 tests pass
- [ ] Manual: hover a text output (no code) — no copy button
- [ ] Manual: hover a fenced code block — copy button appears, copies code text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard functionality by moving code block copy controls from the overall text level to individual code blocks, providing more granular control and better user experience when working with code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->