### PR TITLE
feat: allow overriding docker compose published port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   claude-devtools:
     build: .
     ports:
-      - "3456:3456"
+      - "${PORT:-3456}:3456"
     volumes:
       - ${CLAUDE_DIR:-~/.claude}:/data/.claude:ro
     environment:


### PR DESCRIPTION
Allow the Docker Compose host-side published port to be overridden via `PORT` while keeping the container-side app port fixed at `3456`.

This helps tools such as [Portless](https://port1355.dev/), which launch a process with a dynamically assigned host port and then proxy to that
port. With this change, a command like `portless run docker compose up` can work without changing the app's internal listen port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made the claude-devtools service port configurable via environment variable, defaulting to port 3456 when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->