### PR TITLE
feat: session ID lookup in CommandPalette (Cmd+K)

### DIFF
--- a/src/main/http/search.ts
+++ b/src/main/http/search.ts
@@ -6,8 +6,14 @@
  */
 
 import { createLogger } from '@shared/utils/logger';
+import { isSessionIdFragment } from '@shared/utils/sessionIdValidator';
 
-import { coerceSearchMaxResults, validateProjectId, validateSearchQuery } from '../ipc/guards';
+import {
+  coerceSearchMaxResults,
+  validateProjectId,
+  validateSearchQuery,
+  validateSessionId,
+} from '../ipc/guards';
 
 import type { HttpServices } from './index';
 import type { FastifyInstance } from 'fastify';
@@ -73,6 +79,40 @@ export function registerSearchRoutes(app: FastifyInstance, services: HttpService
     } catch (error) {
       logger.error('Error in GET global search:', error);
       return { results: [], totalMatches: 0, sessionsSearched: 0, query };
+    }
+  });
+
+  app.get<{
+    Params: { sessionId: string };
+  }>('/api/sessions/:sessionId/locate', async (request) => {
+    try {
+      const validated = validateSessionId(request.params.sessionId);
+      if (!validated.valid) {
+        logger.error(`GET locate session rejected: ${validated.error ?? 'Invalid sessionId'}`);
+        return { found: false };
+      }
+
+      return await services.projectScanner.findSessionById(validated.value!);
+    } catch (error) {
+      logger.error(`Error in GET locate session ${request.params.sessionId}:`, error);
+      return { found: false };
+    }
+  });
+
+  app.get<{
+    Params: { fragment: string };
+  }>('/api/sessions/search-by-id/:fragment', async (request) => {
+    try {
+      const fragment = request.params.fragment;
+      if (!fragment || !isSessionIdFragment(fragment)) {
+        logger.error('GET search-by-id rejected: invalid fragment');
+        return { found: false, results: [] };
+      }
+
+      return await services.projectScanner.findSessionsByPartialId(fragment);
+    } catch (error) {
+      logger.error(`Error in GET search-by-id ${request.params.fragment}:`, error);
+      return { found: false, results: [] };
     }
   });
 }

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -6,11 +6,21 @@
  */
 
 import { createLogger } from '@shared/utils/logger';
+import { isSessionIdFragment } from '@shared/utils/sessionIdValidator';
 import { type IpcMain, type IpcMainInvokeEvent } from 'electron';
 
-import { type SearchSessionsResult } from '../types';
+import {
+  type FindSessionByIdResult,
+  type FindSessionsByPartialIdResult,
+  type SearchSessionsResult,
+} from '../types';
 
-import { coerceSearchMaxResults, validateProjectId, validateSearchQuery } from './guards';
+import {
+  coerceSearchMaxResults,
+  validateProjectId,
+  validateSearchQuery,
+  validateSessionId,
+} from './guards';
 
 const logger = createLogger('IPC:search');
 
@@ -32,6 +42,8 @@ export function initializeSearchHandlers(contextRegistry: ServiceContextRegistry
 export function registerSearchHandlers(ipcMain: IpcMain): void {
   ipcMain.handle('search-sessions', handleSearchSessions);
   ipcMain.handle('search-all-projects', handleSearchAllProjects);
+  ipcMain.handle('find-session-by-id', handleFindSessionById);
+  ipcMain.handle('find-sessions-by-partial-id', handleFindSessionsByPartialId);
 
   logger.info('Search handlers registered');
 }
@@ -42,6 +54,8 @@ export function registerSearchHandlers(ipcMain: IpcMain): void {
 export function removeSearchHandlers(ipcMain: IpcMain): void {
   ipcMain.removeHandler('search-sessions');
   ipcMain.removeHandler('search-all-projects');
+  ipcMain.removeHandler('find-session-by-id');
+  ipcMain.removeHandler('find-sessions-by-partial-id');
 
   logger.info('Search handlers removed');
 }
@@ -107,5 +121,50 @@ async function handleSearchAllProjects(
   } catch (error) {
     logger.error('Error in search-all-projects:', error);
     return { results: [], totalMatches: 0, sessionsSearched: 0, query };
+  }
+}
+
+/**
+ * Handler for 'find-session-by-id' IPC call.
+ * Finds a session by its UUID across all projects.
+ */
+async function handleFindSessionById(
+  _event: IpcMainInvokeEvent,
+  sessionId: string
+): Promise<FindSessionByIdResult> {
+  try {
+    const validatedSession = validateSessionId(sessionId);
+    if (!validatedSession.valid) {
+      logger.error(`find-session-by-id rejected: ${validatedSession.error ?? 'Invalid sessionId'}`);
+      return { found: false };
+    }
+
+    const { projectScanner } = registry.getActive();
+    return await projectScanner.findSessionById(validatedSession.value!);
+  } catch (error) {
+    logger.error(`Error in find-session-by-id for ${sessionId}:`, error);
+    return { found: false };
+  }
+}
+
+/**
+ * Handler for 'find-sessions-by-partial-id' IPC call.
+ * Finds sessions whose IDs contain the given fragment.
+ */
+async function handleFindSessionsByPartialId(
+  _event: IpcMainInvokeEvent,
+  fragment: string
+): Promise<FindSessionsByPartialIdResult> {
+  try {
+    if (typeof fragment !== 'string' || !isSessionIdFragment(fragment)) {
+      logger.error(`find-sessions-by-partial-id rejected: invalid fragment`);
+      return { found: false, results: [] };
+    }
+
+    const { projectScanner } = registry.getActive();
+    return await projectScanner.findSessionsByPartialId(fragment);
+  } catch (error) {
+    logger.error(`Error in find-sessions-by-partial-id for ${fragment}:`, error);
+    return { found: false, results: [] };
   }
 }

--- a/src/main/services/discovery/ProjectScanner.ts
+++ b/src/main/services/discovery/ProjectScanner.ts
@@ -16,6 +16,8 @@
  */
 
 import {
+  type FindSessionByIdResult,
+  type FindSessionsByPartialIdResult,
   type PaginatedSessionsResult,
   type Project,
   type RepositoryGroup,
@@ -1150,6 +1152,120 @@ export class ProjectScanner {
     } catch (error) {
       logger.error('Error searching all projects:', error);
       return { results: [], totalMatches: 0, sessionsSearched: 0, query };
+    }
+  }
+
+  /**
+   * Finds a session by its UUID across all projects.
+   * Scans all project directories for a matching .jsonl file.
+   *
+   * @param sessionId - UUID of the session to find
+   * @returns FindSessionByIdResult with projectId and session metadata if found
+   */
+  async findSessionById(sessionId: string): Promise<FindSessionByIdResult> {
+    try {
+      const entries = await this.fsProvider.readdir(this.projectsDir).catch(() => []);
+      const projectDirs = entries.filter(
+        (entry) => entry.isDirectory() && isValidEncodedPath(entry.name)
+      );
+
+      // Check project directories in parallel batches for the session file
+      const matches = await this.collectFulfilledInBatches(
+        projectDirs,
+        this.fsProvider.type === 'ssh' ? 8 : 24,
+        async (dir) => {
+          const sessionPath = buildSessionPath(this.projectsDir, dir.name, sessionId);
+          if (await this.fsProvider.exists(sessionPath)) {
+            return dir.name;
+          }
+          return null;
+        }
+      );
+
+      const matchedProjectId = matches.find((m) => m !== null);
+      if (matchedProjectId) {
+        const session = await this.getSessionWithOptions(matchedProjectId, sessionId, {
+          metadataLevel: 'light',
+        });
+        if (session) {
+          return { found: true, projectId: matchedProjectId, session };
+        }
+      }
+
+      return { found: false };
+    } catch (error) {
+      logger.error(`Error finding session by ID ${sessionId}:`, error);
+      return { found: false };
+    }
+  }
+
+  /**
+   * Finds sessions whose IDs contain the given fragment (case-insensitive).
+   * Scans all project directories in parallel and returns matches sorted by recency.
+   *
+   * @param fragment - Partial session ID fragment (min 3 chars, hex-dash chars only)
+   * @returns FindSessionsByPartialIdResult with matching sessions sorted by createdAt desc
+   */
+  async findSessionsByPartialId(
+    fragment: string,
+    maxResults: number = 50
+  ): Promise<FindSessionsByPartialIdResult> {
+    try {
+      const lowerFragment = fragment.toLowerCase();
+      const entries = await this.fsProvider.readdir(this.projectsDir).catch(() => []);
+      const projectDirs = entries.filter(
+        (entry) => entry.isDirectory() && isValidEncodedPath(entry.name)
+      );
+
+      // Scan all project dirs in parallel, collecting matching session filenames
+      const perProjectMatches = await this.collectFulfilledInBatches(
+        projectDirs,
+        this.fsProvider.type === 'ssh' ? 8 : 24,
+        async (dir) => {
+          const projectPath = path.join(this.projectsDir, dir.name);
+          const sessionEntries = await this.fsProvider.readdir(projectPath);
+          const matchingIds = sessionEntries
+            .filter(
+              (e) => e.name.endsWith('.jsonl') && e.name.toLowerCase().includes(lowerFragment)
+            )
+            .map((e) => extractSessionId(e.name));
+          return { projectId: dir.name, sessionIds: matchingIds };
+        }
+      );
+
+      // Flatten and cap filename matches before loading metadata
+      const allMatches: { projectId: string; sessionId: string }[] = [];
+      for (const { projectId, sessionIds } of perProjectMatches) {
+        for (const sessionId of sessionIds) {
+          allMatches.push({ projectId, sessionId });
+          if (allMatches.length >= maxResults) break;
+        }
+        if (allMatches.length >= maxResults) break;
+      }
+
+      if (allMatches.length === 0) {
+        return { found: false, results: [] };
+      }
+
+      const sessions = await this.collectFulfilledInBatches(
+        allMatches,
+        this.fsProvider.type === 'ssh' ? 4 : 16,
+        async (match) => {
+          const session = await this.getSessionWithOptions(match.projectId, match.sessionId, {
+            metadataLevel: 'light',
+          });
+          return session ? { projectId: match.projectId, session } : null;
+        }
+      );
+
+      const results = sessions
+        .filter((s): s is { projectId: string; session: Session } => s !== null)
+        .sort((a, b) => b.session.createdAt - a.session.createdAt);
+
+      return { found: results.length > 0, results };
+    } catch (error) {
+      logger.error(`Error finding sessions by partial ID ${fragment}:`, error);
+      return { found: false, results: [] };
     }
   }
 

--- a/src/main/types/domain.ts
+++ b/src/main/types/domain.ts
@@ -261,6 +261,28 @@ export interface SearchSessionsResult {
   isPartial?: boolean;
 }
 
+/**
+ * Result of finding a session by its ID across all projects.
+ */
+export interface FindSessionByIdResult {
+  /** Whether the session was found */
+  found: boolean;
+  /** Project ID containing the session */
+  projectId?: string;
+  /** Session metadata */
+  session?: Session;
+}
+
+/**
+ * Result of finding sessions by a partial ID fragment across all projects.
+ */
+export interface FindSessionsByPartialIdResult {
+  /** Whether any sessions were found */
+  found: boolean;
+  /** Matching sessions with their project IDs, sorted by recency */
+  results: { projectId: string; session: Session }[];
+}
+
 // =============================================================================
 // Pagination Types
 // =============================================================================

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -139,6 +139,9 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke('search-sessions', projectId, query, maxResults),
   searchAllProjects: (query: string, maxResults?: number) =>
     ipcRenderer.invoke('search-all-projects', query, maxResults),
+  findSessionById: (sessionId: string) => ipcRenderer.invoke('find-session-by-id', sessionId),
+  findSessionsByPartialId: (fragment: string) =>
+    ipcRenderer.invoke('find-sessions-by-partial-id', fragment),
   getSessionDetail: (projectId: string, sessionId: string) =>
     ipcRenderer.invoke('get-session-detail', projectId, sessionId),
   getSessionMetrics: (projectId: string, sessionId: string) =>
@@ -172,8 +175,7 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke('read-mentioned-file', absolutePath, projectRoot, maxTokens),
 
   // Agent config reading
-  readAgentConfigs: (projectRoot: string) =>
-    ipcRenderer.invoke('read-agent-configs', projectRoot),
+  readAgentConfigs: (projectRoot: string) => ipcRenderer.invoke('read-agent-configs', projectRoot),
 
   // Notifications API
   notifications: {

--- a/src/renderer/api/httpClient.ts
+++ b/src/renderer/api/httpClient.ts
@@ -16,6 +16,8 @@ import type {
   ConversationGroup,
   ElectronAPI,
   FileChangeEvent,
+  FindSessionByIdResult,
+  FindSessionsByPartialIdResult,
   HttpServerAPI,
   HttpServerStatus,
   NotificationsAPI,
@@ -220,6 +222,14 @@ export class HttpAPIClient implements ElectronAPI {
     if (maxResults) params.set('maxResults', String(maxResults));
     return this.get<SearchSessionsResult>(`/api/search?${params}`);
   };
+
+  findSessionById = (sessionId: string): Promise<FindSessionByIdResult> =>
+    this.get<FindSessionByIdResult>(`/api/sessions/${encodeURIComponent(sessionId)}/locate`);
+
+  findSessionsByPartialId = (fragment: string): Promise<FindSessionsByPartialIdResult> =>
+    this.get<FindSessionsByPartialIdResult>(
+      `/api/sessions/search-by-id/${encodeURIComponent(fragment)}`
+    );
 
   getSessionDetail = (projectId: string, sessionId: string): Promise<SessionDetail | null> =>
     this.get<SessionDetail | null>(

--- a/src/renderer/components/search/CommandPalette.tsx
+++ b/src/renderer/components/search/CommandPalette.tsx
@@ -16,6 +16,7 @@ import { createLogger } from '@shared/utils/logger';
 import { useShallow } from 'zustand/react/shallow';
 
 const logger = createLogger('Component:CommandPalette');
+import { isSessionIdFragment, isUUID } from '@shared/utils/sessionIdValidator';
 import { formatDistanceToNow } from 'date-fns';
 import {
   Bot,
@@ -30,12 +31,67 @@ import {
 } from 'lucide-react';
 
 import type { RepositoryGroup, SearchResult } from '@renderer/types/data';
+import type { FindSessionByIdResult, FindSessionsByPartialIdResult } from '@shared/types';
 
 // =============================================================================
 // Search Mode Type
 // =============================================================================
 
 type SearchMode = 'projects' | 'sessions';
+
+// =============================================================================
+// Session ID Match Item (used for both exact and partial matches)
+// =============================================================================
+
+interface SessionIdMatchItemProps {
+  projectName: string;
+  sessionTitle: string;
+  messageCount: number;
+  createdAt: number;
+  sessionId: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const SessionIdMatchItemInner = ({
+  projectName,
+  sessionTitle,
+  messageCount,
+  createdAt,
+  sessionId,
+  isSelected,
+  onClick,
+}: Readonly<SessionIdMatchItemProps>): React.JSX.Element => (
+  <button
+    onClick={onClick}
+    className={`w-full px-4 py-3 text-left transition-colors ${
+      isSelected ? 'bg-surface-raised' : 'hover:bg-surface-raised/50'
+    }`}
+  >
+    <div className="flex items-start gap-3">
+      <div className="mt-0.5 shrink-0 text-green-400">
+        <FileText className="size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          <FolderGit2 className="size-3 text-blue-400" />
+          <span className="truncate text-xs font-medium text-blue-400">{projectName}</span>
+        </div>
+        <div className="text-sm text-text">
+          {sessionTitle ? sessionTitle.slice(0, 100) : 'Untitled session'}
+        </div>
+        <div className="mt-1 flex items-center gap-3 text-xs text-text-muted">
+          <span>{messageCount} messages</span>
+          <span>&middot;</span>
+          <span>{formatDistanceToNow(new Date(createdAt), { addSuffix: true })}</span>
+        </div>
+        <div className="text-text-muted/60 mt-1 font-mono text-[10px]">{sessionId}</div>
+      </div>
+    </div>
+  </button>
+);
+
+const SessionIdMatchItem = React.memo(SessionIdMatchItemInner);
 
 // =============================================================================
 // Project Search Result Item
@@ -183,7 +239,35 @@ export const CommandPalette = (): React.JSX.Element | null => {
   const [totalMatches, setTotalMatches] = useState(0);
   const [searchIsPartial, setSearchIsPartial] = useState(false);
   const [globalSearchEnabled, setGlobalSearchEnabled] = useState(false);
+  const [sessionIdMatch, setSessionIdMatch] = useState<FindSessionByIdResult | null>(null);
+  const [partialIdMatches, setPartialIdMatches] = useState<
+    FindSessionsByPartialIdResult['results']
+  >([]);
   const latestSearchRequestRef = useRef(0);
+
+  // Memoize query classification to avoid redundant calls per render
+  const queryIsUUID = useMemo(() => isUUID(query), [query]);
+  const queryIsFragment = useMemo(() => isSessionIdFragment(query), [query]);
+  const queryIsSessionId = queryIsUUID || queryIsFragment;
+
+  // Memoize project ID → repo name lookup map
+  const projectNameByWorktreeId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const repo of repositoryGroups) {
+      for (const wt of repo.worktrees) {
+        map.set(wt.id, repo.name);
+      }
+    }
+    return map;
+  }, [repositoryGroups]);
+
+  // Memoize repository name lookup for the selected project
+  const selectedProjectName = useMemo(
+    () =>
+      (selectedProjectId ? projectNameByWorktreeId.get(selectedProjectId) : undefined) ??
+      'Current project',
+    [projectNameByWorktreeId, selectedProjectId]
+  );
 
   // Determine search mode based on whether a project is selected OR global search is enabled
   const searchMode: SearchMode = selectedProjectId || globalSearchEnabled ? 'sessions' : 'projects';
@@ -206,7 +290,15 @@ export const CommandPalette = (): React.JSX.Element | null => {
   }, [repositoryGroups, query, searchMode]);
 
   // Results count for current mode
-  const resultsCount = searchMode === 'projects' ? filteredProjects.length : sessionResults.length;
+  const resultsCount = queryIsUUID
+    ? sessionIdMatch?.found
+      ? 1
+      : 0
+    : queryIsFragment
+      ? partialIdMatches.length
+      : searchMode === 'projects'
+        ? filteredProjects.length
+        : sessionResults.length;
 
   // Fetch repository groups if needed
   useEffect(() => {
@@ -235,11 +327,84 @@ export const CommandPalette = (): React.JSX.Element | null => {
       setTotalMatches(0);
       setSearchIsPartial(false);
       setGlobalSearchEnabled(false);
+      setSessionIdMatch(null);
+      setPartialIdMatches([]);
     }
   }, [commandPaletteOpen]);
 
-  // Search sessions with debounce (only in session mode)
+  // Detect UUID input and look up session by ID (exact match)
   useEffect(() => {
+    if (!commandPaletteOpen || !queryIsUUID) {
+      setSessionIdMatch(null);
+      return;
+    }
+
+    setPartialIdMatches([]);
+    const timeoutId = setTimeout(async () => {
+      const requestId = latestSearchRequestRef.current + 1;
+      latestSearchRequestRef.current = requestId;
+      setLoading(true);
+      try {
+        const result = await api.findSessionById(query.trim());
+        if (latestSearchRequestRef.current !== requestId) return;
+        setSessionIdMatch(result);
+        setSessionResults([]);
+        setTotalMatches(0);
+        setSearchIsPartial(false);
+        setSelectedIndex(0);
+      } catch (error) {
+        if (latestSearchRequestRef.current !== requestId) return;
+        logger.error('Session ID lookup error:', error);
+        setSessionIdMatch(null);
+      } finally {
+        if (latestSearchRequestRef.current === requestId) {
+          setLoading(false);
+        }
+      }
+    }, 50);
+
+    return () => clearTimeout(timeoutId);
+  }, [query, commandPaletteOpen, queryIsUUID]);
+
+  // Detect partial session ID fragment and look up matching sessions
+  useEffect(() => {
+    if (!commandPaletteOpen || !queryIsFragment) {
+      setPartialIdMatches([]);
+      return;
+    }
+
+    setSessionIdMatch(null);
+    setSessionResults([]);
+    const timeoutId = setTimeout(async () => {
+      const requestId = latestSearchRequestRef.current + 1;
+      latestSearchRequestRef.current = requestId;
+      setLoading(true);
+      try {
+        const result = await api.findSessionsByPartialId(query.trim());
+        if (latestSearchRequestRef.current !== requestId) return;
+        setPartialIdMatches(result.results);
+        setSelectedIndex(0);
+      } catch (error) {
+        if (latestSearchRequestRef.current !== requestId) return;
+        logger.error('Partial session ID lookup error:', error);
+        setPartialIdMatches([]);
+      } finally {
+        if (latestSearchRequestRef.current === requestId) {
+          setLoading(false);
+        }
+      }
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [query, commandPaletteOpen, queryIsFragment]);
+
+  // Search sessions with debounce (only in session mode, skip when session ID detected)
+  useEffect(() => {
+    // Skip text search when query is a UUID or fragment (handled by dedicated lookups above)
+    if (queryIsSessionId) {
+      return;
+    }
+
     // Only clear results when query is too short or palette is closed
     if (!commandPaletteOpen || query.trim().length < 2) {
       setSessionResults([]);
@@ -284,7 +449,14 @@ export const CommandPalette = (): React.JSX.Element | null => {
     }, 400);
 
     return () => clearTimeout(timeoutId);
-  }, [query, selectedProjectId, commandPaletteOpen, searchMode, globalSearchEnabled]);
+  }, [
+    query,
+    selectedProjectId,
+    commandPaletteOpen,
+    searchMode,
+    globalSearchEnabled,
+    queryIsSessionId,
+  ]);
 
   // Reset selected index when results change
   useEffect(() => {
@@ -298,6 +470,23 @@ export const CommandPalette = (): React.JSX.Element | null => {
       selectRepository(repo.id);
     },
     [closeCommandPalette, selectRepository]
+  );
+
+  // Handle session ID match click (direct navigation)
+  const handleSessionIdMatchClick = useCallback(() => {
+    if (sessionIdMatch?.found && sessionIdMatch.projectId && sessionIdMatch.session) {
+      closeCommandPalette();
+      navigateToSession(sessionIdMatch.projectId, sessionIdMatch.session.id, false);
+    }
+  }, [closeCommandPalette, navigateToSession, sessionIdMatch]);
+
+  // Handle partial ID match click
+  const handlePartialMatchClick = useCallback(
+    (projectId: string, sessionId: string) => {
+      closeCommandPalette();
+      navigateToSession(projectId, sessionId, false);
+    },
+    [closeCommandPalette, navigateToSession]
   );
 
   // Handle session result click
@@ -354,17 +543,32 @@ export const CommandPalette = (): React.JSX.Element | null => {
         return;
       }
 
-      if (e.key === 'Enter' && resultsCount > 0) {
+      if (e.key === 'Enter') {
         e.preventDefault();
-        if (searchMode === 'projects') {
-          const selected = filteredProjects[selectedIndex];
+        // Handle UUID session ID match
+        if (queryIsUUID && sessionIdMatch?.found) {
+          handleSessionIdMatchClick();
+          return;
+        }
+        // Handle partial ID match selection
+        if (queryIsFragment && partialIdMatches.length > 0) {
+          const selected = partialIdMatches[selectedIndex];
           if (selected) {
-            handleProjectClick(selected);
+            handlePartialMatchClick(selected.projectId, selected.session.id);
           }
-        } else {
-          const selected = sessionResults[selectedIndex];
-          if (selected) {
-            handleSessionResultClick(selected);
+          return;
+        }
+        if (resultsCount > 0) {
+          if (searchMode === 'projects') {
+            const selected = filteredProjects[selectedIndex];
+            if (selected) {
+              handleProjectClick(selected);
+            }
+          } else {
+            const selected = sessionResults[selectedIndex];
+            if (selected) {
+              handleSessionResultClick(selected);
+            }
           }
         }
       }
@@ -376,8 +580,14 @@ export const CommandPalette = (): React.JSX.Element | null => {
       searchMode,
       filteredProjects,
       sessionResults,
+      sessionIdMatch,
+      partialIdMatches,
+      queryIsUUID,
+      queryIsFragment,
       handleProjectClick,
       handleSessionResultClick,
+      handleSessionIdMatchClick,
+      handlePartialMatchClick,
     ]
   );
 
@@ -427,7 +637,12 @@ export const CommandPalette = (): React.JSX.Element | null => {
         <div className="bg-surface-raised/50 border-b border-border px-4 py-2">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              {searchMode === 'projects' ? (
+              {queryIsSessionId ? (
+                <>
+                  <Search className="size-3.5 text-green-400" />
+                  <span className="text-xs text-green-400">Session ID search</span>
+                </>
+              ) : searchMode === 'projects' ? (
                 <>
                   <FolderGit2 className="size-3.5 text-text-muted" />
                   <span className="text-xs text-text-muted">Search projects</span>
@@ -440,11 +655,9 @@ export const CommandPalette = (): React.JSX.Element | null => {
                   </span>
                   {!globalSearchEnabled && (
                     <>
-                      <span className="text-text-muted/50 mx-1 text-xs">·</span>
+                      <span className="text-text-muted/50 mx-1 text-xs">&middot;</span>
                       <span className="truncate text-xs text-text-secondary">
-                        {repositoryGroups.find((r) =>
-                          r.worktrees.some((w) => w.id === selectedProjectId)
-                        )?.name ?? 'Current project'}
+                        {selectedProjectName}
                       </span>
                     </>
                   )}
@@ -480,7 +693,9 @@ export const CommandPalette = (): React.JSX.Element | null => {
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={
-              searchMode === 'projects' ? 'Search projects...' : 'Search conversations...'
+              searchMode === 'projects'
+                ? 'Search projects or paste session ID...'
+                : 'Search conversations or paste session ID...'
             }
             className="placeholder:text-text-muted/50 flex-1 bg-transparent text-base text-text focus:outline-none"
           />
@@ -495,7 +710,54 @@ export const CommandPalette = (): React.JSX.Element | null => {
 
         {/* Results */}
         <div className="max-h-[50vh] overflow-y-auto">
-          {searchMode === 'projects' ? (
+          {queryIsUUID ? (
+            // Exact UUID lookup result
+            loading ? null : sessionIdMatch?.found && sessionIdMatch.session ? (
+              <div className="py-2">
+                <SessionIdMatchItem
+                  projectName={
+                    (sessionIdMatch.projectId
+                      ? projectNameByWorktreeId.get(sessionIdMatch.projectId)
+                      : undefined) ??
+                    sessionIdMatch.projectId ??
+                    'Unknown'
+                  }
+                  sessionTitle={sessionIdMatch.session.firstMessage ?? ''}
+                  messageCount={sessionIdMatch.session.messageCount}
+                  createdAt={sessionIdMatch.session.createdAt}
+                  sessionId={query.trim()}
+                  isSelected
+                  onClick={handleSessionIdMatchClick}
+                />
+              </div>
+            ) : (
+              <div className="px-4 py-8 text-center text-sm text-text-muted">
+                No session found with ID &ldquo;{query.trim().slice(0, 8)}...&rdquo;
+              </div>
+            )
+          ) : queryIsFragment ? (
+            // Partial session ID fragment results
+            loading ? null : partialIdMatches.length > 0 ? (
+              <div className="py-2">
+                {partialIdMatches.map((match, index) => (
+                  <SessionIdMatchItem
+                    key={match.session.id}
+                    projectName={projectNameByWorktreeId.get(match.projectId) ?? match.projectId}
+                    sessionTitle={match.session.firstMessage ?? ''}
+                    messageCount={match.session.messageCount}
+                    createdAt={match.session.createdAt}
+                    sessionId={match.session.id}
+                    isSelected={index === selectedIndex}
+                    onClick={() => handlePartialMatchClick(match.projectId, match.session.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="px-4 py-8 text-center text-sm text-text-muted">
+                No sessions found matching &ldquo;{query.trim()}&rdquo;
+              </div>
+            )
+          ) : searchMode === 'projects' ? (
             // Project search results
             filteredProjects.length === 0 ? (
               <div className="px-4 py-8 text-center text-sm text-text-muted">
@@ -527,10 +789,8 @@ export const CommandPalette = (): React.JSX.Element | null => {
           ) : (
             <div className="py-2">
               {sessionResults.map((result, index) => {
-                // Find project name for this result when in global search mode
                 const projectName = globalSearchEnabled
-                  ? repositoryGroups.find((r) => r.worktrees.some((w) => w.id === result.projectId))
-                      ?.name
+                  ? projectNameByWorktreeId.get(result.projectId)
                   : undefined;
 
                 return (

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -17,6 +17,8 @@ import type { WaterfallData } from './visualization';
 import type {
   ConversationGroup,
   FileChangeEvent,
+  FindSessionByIdResult,
+  FindSessionsByPartialIdResult,
   PaginatedSessionsResult,
   Project,
   RepositoryGroup,
@@ -337,6 +339,8 @@ export interface ElectronAPI {
     maxResults?: number
   ) => Promise<SearchSessionsResult>;
   searchAllProjects: (query: string, maxResults?: number) => Promise<SearchSessionsResult>;
+  findSessionById: (sessionId: string) => Promise<FindSessionByIdResult>;
+  findSessionsByPartialId: (fragment: string) => Promise<FindSessionsByPartialIdResult>;
   getSessionDetail: (projectId: string, sessionId: string) => Promise<SessionDetail | null>;
   getSessionMetrics: (projectId: string, sessionId: string) => Promise<SessionMetrics | null>;
   getWaterfallData: (projectId: string, sessionId: string) => Promise<WaterfallData | null>;

--- a/src/shared/utils/sessionIdValidator.ts
+++ b/src/shared/utils/sessionIdValidator.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared session ID validation utilities.
+ * Used by both renderer (CommandPalette) and main (IPC/HTTP handlers).
+ */
+
+/** Matches a standard v4 UUID (case-insensitive). */
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Matches a session ID fragment: starts with hex, followed by 2+ hex-or-dash chars. */
+export const SESSION_FRAGMENT_REGEX = /^[0-9a-f][0-9a-f-]{2,}$/i;
+
+/** Minimum length for a valid session ID fragment. */
+export const MIN_FRAGMENT_LENGTH = 3;
+
+export function isUUID(value: string): boolean {
+  return UUID_REGEX.test(value.trim());
+}
+
+/**
+ * Detects a session ID fragment: 3+ hex-dash chars that aren't a full UUID.
+ */
+export function isSessionIdFragment(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.length >= MIN_FRAGMENT_LENGTH &&
+    !isUUID(trimmed) &&
+    SESSION_FRAGMENT_REGEX.test(trimmed)
+  );
+}

--- a/test/main/ipc/searchSessionId.test.ts
+++ b/test/main/ipc/searchSessionId.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Interface contract tests for session ID lookup IPC handlers.
+ * Tests the validation layer — guards.ts and sessionIdValidator — that
+ * protects find-session-by-id and find-sessions-by-partial-id.
+ * Follows the pattern in test/main/ipc/guards.test.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { validateSessionId } from '../../../src/main/ipc/guards';
+import { isSessionIdFragment } from '../../../src/shared/utils/sessionIdValidator';
+
+// =============================================================================
+// find-session-by-id guard layer
+// =============================================================================
+
+describe('find-session-by-id: guard layer (validateSessionId)', () => {
+  it('rejects empty string — handler returns { found: false }', () => {
+    const result = validateSessionId('');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects string with invalid characters (shell-injection attempt)', () => {
+    const result = validateSessionId('$(rm -rf)');
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts a valid UUID — passes guard, scanner determines found/not-found', () => {
+    const result = validateSessionId('550e8400-e29b-41d4-a716-446655440000');
+    expect(result.valid).toBe(true);
+    expect(result.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('accepted input produces { found: false } shape when scanner finds nothing', () => {
+    // The handler's early-exit shape on invalid input
+    const invalidResult = validateSessionId('');
+    if (!invalidResult.valid) {
+      const handlerEarlyReturn = { found: false } as const;
+      expect(handlerEarlyReturn.found).toBe(false);
+    }
+  });
+});
+
+// =============================================================================
+// find-sessions-by-partial-id guard layer
+// =============================================================================
+
+describe('find-sessions-by-partial-id: guard layer (isSessionIdFragment)', () => {
+  it('rejects fragment shorter than 3 chars (2 chars)', () => {
+    expect(isSessionIdFragment('ab')).toBe(false);
+  });
+
+  it('rejects single char', () => {
+    expect(isSessionIdFragment('a')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isSessionIdFragment('')).toBe(false);
+  });
+
+  it('rejects non-hex characters', () => {
+    expect(isSessionIdFragment('xyz')).toBe(false);
+  });
+
+  it('rejects full UUID (treated as exact, not partial)', () => {
+    expect(isSessionIdFragment('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+  });
+
+  it('accepts minimum-length hex fragment (3 chars)', () => {
+    expect(isSessionIdFragment('abc')).toBe(true);
+  });
+
+  it('accepts hex fragment with dashes', () => {
+    expect(isSessionIdFragment('abc-def')).toBe(true);
+  });
+
+  it('rejected input produces { found: false, results: [] } shape', () => {
+    const fragment = 'xy';
+    if (!isSessionIdFragment(fragment)) {
+      const handlerEarlyReturn = { found: false, results: [] } as const;
+      expect(handlerEarlyReturn.found).toBe(false);
+      expect(handlerEarlyReturn.results).toHaveLength(0);
+    }
+  });
+});

--- a/test/shared/utils/sessionIdValidator.test.ts
+++ b/test/shared/utils/sessionIdValidator.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSessionIdFragment,
+  isUUID,
+  MIN_FRAGMENT_LENGTH,
+  SESSION_FRAGMENT_REGEX,
+  UUID_REGEX,
+} from '../../../src/shared/utils/sessionIdValidator';
+
+describe('sessionIdValidator', () => {
+  describe('isUUID', () => {
+    it('accepts a valid v4 UUID', () => {
+      expect(isUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    });
+
+    it('accepts uppercase UUID', () => {
+      expect(isUUID('550E8400-E29B-41D4-A716-446655440000')).toBe(true);
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(isUUID('  550e8400-e29b-41d4-a716-446655440000  ')).toBe(true);
+    });
+
+    it('rejects a partial UUID (too short)', () => {
+      expect(isUUID('550e8400-e29b')).toBe(false);
+    });
+
+    it('rejects non-hex characters', () => {
+      expect(isUUID('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz')).toBe(false);
+    });
+
+    it('rejects an empty string', () => {
+      expect(isUUID('')).toBe(false);
+    });
+  });
+
+  describe('isSessionIdFragment', () => {
+    it('accepts exact minimum length (3 chars)', () => {
+      expect(isSessionIdFragment('abc')).toBe(true);
+    });
+
+    it('rejects 2 chars (below minimum)', () => {
+      expect(isSessionIdFragment('ab')).toBe(false);
+    });
+
+    it('accepts hex-with-dashes', () => {
+      expect(isSessionIdFragment('abc-def')).toBe(true);
+    });
+
+    it('rejects a full UUID', () => {
+      expect(isSessionIdFragment('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+    });
+
+    it('rejects non-hex characters', () => {
+      expect(isSessionIdFragment('xyz')).toBe(false);
+    });
+
+    it('rejects an empty string', () => {
+      expect(isSessionIdFragment('')).toBe(false);
+    });
+  });
+
+  describe('exported constants', () => {
+    it('exports UUID_REGEX as a RegExp', () => {
+      expect(UUID_REGEX).toBeInstanceOf(RegExp);
+    });
+
+    it('exports SESSION_FRAGMENT_REGEX as a RegExp', () => {
+      expect(SESSION_FRAGMENT_REGEX).toBeInstanceOf(RegExp);
+    });
+
+    it('exports MIN_FRAGMENT_LENGTH as 3', () => {
+      expect(MIN_FRAGMENT_LENGTH).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add session ID lookup to CommandPalette (Cmd+K): paste a full UUID or type a hex fragment (3+ chars) to instantly navigate to a session
- Auto-detect UUID vs fragment vs text query — switches mode indicator to green "Session ID search" label
- New `sessionIdValidator` shared utility (`isUUID`, `isSessionIdFragment`) used by both IPC/HTTP validation layers and the renderer
- New `ProjectScanner.findSessionById` / `findSessionsByPartialId` methods scan all projects
- New IPC handlers: `find-session-by-id`, `find-sessions-by-partial-id`
- New HTTP routes: `GET /api/sessions/:sessionId/locate`, `GET /api/sessions/search-by-id/:fragment`
- 27 new tests (validator boundary cases + IPC guard contracts)

Closes #151

## Test plan

- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean (pre-existing unrelated warning only)
- [ ] `pnpm test` — 680/680 pass
- [ ] `pnpm build` — clean
- [ ] Open Cmd+K, paste a full session UUID → shows "Session ID search" mode, navigates to session
- [ ] Open Cmd+K, type 3+ hex chars → shows matching sessions by partial ID
- [ ] Open Cmd+K, type regular text → normal project/session search mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette: search by full session ID to directly locate a session.
  * Command palette: search by partial session ID fragments to list matching sessions with project context.
  * Keyboard/selection: Enter now navigates directly to exact or partial session matches and updates UI mode and placeholders for session-ID searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->