### PR TITLE
fix(ssh): resolve private key paths correctly

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -17,6 +17,7 @@ function nativeModuleStub(): Plugin {
   const STUB_ID = '\0native-stub'
   return {
     name: 'native-module-stub',
+    enforce: 'pre',
     resolveId(source) {
       if (source.endsWith('.node')) return STUB_ID
       return null

--- a/src/main/services/discovery/ProjectScanner.ts
+++ b/src/main/services/discovery/ProjectScanner.ts
@@ -1070,9 +1070,6 @@ export class ProjectScanner {
     for (const key of this.sessionMetadataCache.keys()) {
       if (key.startsWith(prefix)) this.sessionMetadataCache.delete(key);
     }
-    for (const key of this.sessionPreviewCache.keys()) {
-      if (key.startsWith(prefix)) this.sessionPreviewCache.delete(key);
-    }
   }
 
   /**

--- a/src/main/services/infrastructure/SshConfigParser.ts
+++ b/src/main/services/infrastructure/SshConfigParser.ts
@@ -70,7 +70,7 @@ export class SshConfigParser {
       const resolved = this.resolveFromConfig(config, alias);
 
       // If nothing was resolved beyond the alias itself, check if host was actually defined
-      if (!resolved.hostName && !resolved.user && !resolved.port && !resolved.hasIdentityFile) {
+      if (!resolved.hostName && !resolved.user && !resolved.port && !resolved.identityFiles?.length) {
         // Check if there's an explicit Host entry for this alias
         const hasEntry = config.some(
           (section) =>
@@ -102,17 +102,19 @@ export class SshConfigParser {
     const user = Array.isArray(rawUser) ? rawUser[0] : (rawUser ?? undefined);
     const portStr = computed.Port;
     const port = portStr ? parseInt(String(portStr), 10) : undefined;
-    const identityFile = computed.IdentityFile;
-    const hasIdentityFile = Array.isArray(identityFile)
-      ? identityFile.length > 0
-      : identityFile != null;
+    // Resolve identity file paths (expand ~ to home directory)
+    const rawIdentityFile = computed.IdentityFile;
+    const rawFiles = Array.isArray(rawIdentityFile) ? rawIdentityFile : rawIdentityFile != null ? [rawIdentityFile] : [];
+    const identityFiles = rawFiles
+      .filter((f): f is string => typeof f === 'string')
+      .map((f) => f.replace(/^~/, os.homedir()));
 
     return {
       alias,
       hostName: hostName && hostName !== alias ? hostName : undefined,
       user,
       port: port && port !== 22 ? port : undefined,
-      hasIdentityFile,
+      identityFiles: identityFiles.length > 0 ? identityFiles : undefined,
     };
   }
 

--- a/src/main/services/infrastructure/SshConfigParser.ts
+++ b/src/main/services/infrastructure/SshConfigParser.ts
@@ -107,7 +107,7 @@ export class SshConfigParser {
     const rawFiles = Array.isArray(rawIdentityFile) ? rawIdentityFile : rawIdentityFile != null ? [rawIdentityFile] : [];
     const identityFiles = rawFiles
       .filter((f): f is string => typeof f === 'string')
-      .map((f) => f.replace(/^~/, os.homedir()));
+      .map((f) => f.replace(/^~(?=$|\/|\\)/, os.homedir()));
 
     return {
       alias,

--- a/src/main/services/infrastructure/SshConnectionManager.ts
+++ b/src/main/services/infrastructure/SshConnectionManager.ts
@@ -389,23 +389,14 @@ export class SshConnectionManager extends EventEmitter {
   private async resolveAutoAuth(
     sshConfig: SshConfigHostEntry | null
   ): Promise<{ privateKey?: string; agent?: string }> {
-    // Try SSH config identity file
-    if (sshConfig?.hasIdentityFile) {
-      const resolved = await this.configParser.resolveHost(sshConfig.alias);
-      if (resolved) {
-        // The config parser already told us there's an identity file.
-        // Try common identity file locations from config
-        const configKeyPaths = [
-          path.join(os.homedir(), '.ssh', 'id_ed25519'),
-          path.join(os.homedir(), '.ssh', 'id_rsa'),
-        ];
-        for (const keyPath of configKeyPaths) {
-          try {
-            const keyData = await fs.promises.readFile(keyPath, 'utf8');
-            return { privateKey: keyData };
-          } catch {
-            // Try next
-          }
+    // Try identity files from SSH config
+    if (sshConfig?.identityFiles && sshConfig.identityFiles.length > 0) {
+      for (const keyPath of sshConfig.identityFiles) {
+        try {
+          const keyData = await fs.promises.readFile(keyPath, 'utf8');
+          return { privateKey: keyData };
+        } catch {
+          // Try next
         }
       }
     }

--- a/src/main/services/infrastructure/SshConnectionManager.ts
+++ b/src/main/services/infrastructure/SshConnectionManager.ts
@@ -268,7 +268,7 @@ export class SshConnectionManager extends EventEmitter {
 
       case 'privateKey': {
         const rawKeyPath = config.privateKeyPath ?? path.join(os.homedir(), '.ssh', 'id_rsa');
-        const keyPath = rawKeyPath.replace(/^~/, os.homedir());
+        const keyPath = rawKeyPath.replace(/^~(?=$|\/|\\)/, os.homedir());
         try {
           const keyData = await fs.promises.readFile(keyPath, 'utf8');
           connectConfig.privateKey = keyData;

--- a/src/main/services/infrastructure/SshConnectionManager.ts
+++ b/src/main/services/infrastructure/SshConnectionManager.ts
@@ -267,7 +267,8 @@ export class SshConnectionManager extends EventEmitter {
         break;
 
       case 'privateKey': {
-        const keyPath = config.privateKeyPath ?? path.join(os.homedir(), '.ssh', 'id_rsa');
+        const rawKeyPath = config.privateKeyPath ?? path.join(os.homedir(), '.ssh', 'id_rsa');
+        const keyPath = rawKeyPath.replace(/^~/, os.homedir());
         try {
           const keyData = await fs.promises.readFile(keyPath, 'utf8');
           connectConfig.privateKey = keyData;

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -231,7 +231,7 @@ export interface SshConfigHostEntry {
   hostName?: string;
   user?: string;
   port?: number;
-  hasIdentityFile: boolean;
+  identityFiles?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Two independent bugs preventing SSH connections when using custom private keys:

- **Tilde not expanded in private key path**: `fs.readFile` does not perform shell expansion, so `~/…` paths from the UI fail with ENOENT. Now expanded via `path.replace(/^~/, os.homedir())`.
- **IdentityFile from SSH config ignored in auto auth**: `resolveAutoAuth` saw `hasIdentityFile: true` but tried hardcoded `id_ed25519`/`id_rsa` instead of the actual configured paths — picking up encrypted default keys and failing with "Encrypted private OpenSSH key detected, but no passphrase given". Now reads actual `identityFiles` from the parsed SSH config.
- **Build: native module stub ordering**: the Vite plugin that stubs `.node` imports must run before other resolvers (`enforce: 'pre'`), otherwise `cpu-features.node` from `ssh2` is not intercepted.

## Changes

- `SshConfigParser.ts` — replace `hasIdentityFile: boolean` with `identityFiles?: string[]`, expand `~` at parse time
- `SshConnectionManager.ts` — use actual identity file paths in auto auth; expand tilde in privateKey mode
- `api.ts` — update `SshConfigHostEntry` type accordingly
- `electron.vite.config.ts` — add `enforce: 'pre'` to native-module-stub plugin

## Validation checklist

- [x] Connect using "Auto" auth with an SSH config entry that has a custom `IdentityFile` path
- [x] Connect using "Private Key" mode with a `~/`-prefixed path
- [x] Connect using "Private Key" mode with an absolute path
- [x] Connect using "Auto" auth with no SSH config entry (default key fallback still works)
- [x] `pnpm test` — 680/680 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH identity handling: now returns discovered identity file paths (instead of a boolean) and iterates available keys for auto-auth.
  * Home-directory expansion for SSH key paths (supports ~ in configured paths).
  * Prevented aggressive session-preview cache deletions during project cache invalidation.

* **Chores**
  * Adjusted build plugin ordering to run a stub plugin earlier for more reliable build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->