### PR TITLE
feat: add setting to keep AI groups expanded after context navigation

### DIFF
--- a/src/main/ipc/configValidation.ts
+++ b/src/main/ipc/configValidation.ts
@@ -302,6 +302,7 @@ function validateDisplaySection(data: unknown): ValidationSuccess<'display'> | V
     'showTimestamps',
     'compactMode',
     'syntaxHighlighting',
+    'keepContextNavExpanded',
   ];
 
   const result: Partial<DisplayConfig> = {};

--- a/src/main/services/infrastructure/ConfigManager.ts
+++ b/src/main/services/infrastructure/ConfigManager.ts
@@ -189,6 +189,7 @@ export interface DisplayConfig {
   showTimestamps: boolean;
   compactMode: boolean;
   syntaxHighlighting: boolean;
+  keepContextNavExpanded: boolean;
 }
 
 export interface SessionsConfig {
@@ -257,6 +258,7 @@ const DEFAULT_CONFIG: AppConfig = {
     showTimestamps: true,
     compactMode: false,
     syntaxHighlighting: true,
+    keepContextNavExpanded: false,
   },
   sessions: {
     pinnedSessions: {},

--- a/src/renderer/components/chat/ChatHistory.tsx
+++ b/src/renderer/components/chat/ChatHistory.tsx
@@ -415,6 +415,9 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
         if (!element) return;
 
         element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        if (useStore.getState().appConfig?.display?.keepContextNavExpanded) {
+          expandAIGroup(groupId);
+        }
         setHighlightedGroupId(groupId);
         setIsNavigationHighlight(true);
         if (navigationHighlightTimerRef.current) {
@@ -428,7 +431,7 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
       };
       void run();
     },
-    [conversation, ensureGroupVisible, setHighlightedGroupId]
+    [conversation, ensureGroupVisible, setHighlightedGroupId, expandAIGroup]
   );
 
   // Handler to navigate to a user message group (preceding the AI group at turnIndex)
@@ -481,6 +484,9 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
         await ensureGroupVisible(groupId);
 
         // Set group + tool highlight immediately
+        if (useStore.getState().appConfig?.display?.keepContextNavExpanded) {
+          expandAIGroup(groupId);
+        }
         setHighlightedGroupId(groupId);
         setIsNavigationHighlight(true);
         setContextNavToolUseId(toolUseId);
@@ -513,7 +519,7 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
       };
       void run();
     },
-    [conversation, ensureGroupVisible, setHighlightedGroupId]
+    [conversation, ensureGroupVisible, setHighlightedGroupId, expandAIGroup]
   );
 
   // Scroll to current search result when it changes

--- a/src/renderer/components/settings/SettingsView.tsx
+++ b/src/renderer/components/settings/SettingsView.tsx
@@ -127,6 +127,7 @@ export const SettingsView = (): React.JSX.Element | null => {
               safeConfig={safeConfig}
               saving={saving}
               onGeneralToggle={handlers.handleGeneralToggle}
+              onDisplayToggle={handlers.handleDisplayToggle}
               onThemeChange={handlers.handleThemeChange}
             />
           )}

--- a/src/renderer/components/settings/hooks/useSettingsConfig.ts
+++ b/src/renderer/components/settings/hooks/useSettingsConfig.ts
@@ -47,6 +47,7 @@ export interface SafeConfig {
     showTimestamps: boolean;
     compactMode: boolean;
     syntaxHighlighting: boolean;
+    keepContextNavExpanded: boolean;
   };
 }
 
@@ -173,6 +174,7 @@ export function useSettingsConfig(): UseSettingsConfigReturn {
         showTimestamps: displayConfig?.display?.showTimestamps ?? true,
         compactMode: displayConfig?.display?.compactMode ?? false,
         syntaxHighlighting: displayConfig?.display?.syntaxHighlighting ?? true,
+        keepContextNavExpanded: displayConfig?.display?.keepContextNavExpanded ?? false,
       },
     }),
     [displayConfig]

--- a/src/renderer/components/settings/hooks/useSettingsHandlers.ts
+++ b/src/renderer/components/settings/hooks/useSettingsHandlers.ts
@@ -294,6 +294,7 @@ export function useSettingsHandlers({
           showTimestamps: true,
           compactMode: false,
           syntaxHighlighting: true,
+          keepContextNavExpanded: false,
         },
         sessions: {
           pinnedSessions: {},

--- a/src/renderer/components/settings/sections/GeneralSection.tsx
+++ b/src/renderer/components/settings/sections/GeneralSection.tsx
@@ -28,6 +28,7 @@ interface GeneralSectionProps {
   readonly safeConfig: SafeConfig;
   readonly saving: boolean;
   readonly onGeneralToggle: (key: keyof AppConfig['general'], value: boolean) => void;
+  readonly onDisplayToggle: (key: keyof AppConfig['display'], value: boolean) => void;
   readonly onThemeChange: (value: 'dark' | 'light' | 'system') => void;
 }
 
@@ -35,6 +36,7 @@ export const GeneralSection = ({
   safeConfig,
   saving,
   onGeneralToggle,
+  onDisplayToggle,
   onThemeChange,
 }: GeneralSectionProps): React.JSX.Element => {
   const [serverStatus, setServerStatus] = useState<HttpServerStatus>({
@@ -294,6 +296,16 @@ export const GeneralSection = ({
         <SettingsToggle
           enabled={safeConfig.general.autoExpandAIGroups ?? false}
           onChange={(v) => onGeneralToggle('autoExpandAIGroups', v)}
+          disabled={saving}
+        />
+      </SettingRow>
+      <SettingRow
+        label="Keep expanded after context navigation"
+        description="Keep AI response groups expanded after navigating to them from the Visible Context panel"
+      >
+        <SettingsToggle
+          enabled={safeConfig.display.keepContextNavExpanded}
+          onChange={(v) => onDisplayToggle('keepContextNavExpanded', v)}
           disabled={saving}
         />
       </SettingRow>

--- a/src/shared/types/notifications.ts
+++ b/src/shared/types/notifications.ts
@@ -275,6 +275,8 @@ export interface AppConfig {
     compactMode: boolean;
     /** Whether to enable syntax highlighting in code blocks */
     syntaxHighlighting: boolean;
+    /** Whether to keep AI groups expanded after navigating from the Visible Context panel */
+    keepContextNavExpanded: boolean;
   };
   /** Session-related settings */
   sessions: {

--- a/test/mocks/electronAPI.ts
+++ b/test/mocks/electronAPI.ts
@@ -148,6 +148,7 @@ export function createMockElectronAPI(): MockElectronAPI {
           showTimestamps: true,
           compactMode: false,
           syntaxHighlighting: true,
+          keepContextNavExpanded: false,
         },
         sessions: {
           pinnedSessions: {},


### PR DESCRIPTION
## Summary

Navigating from the Visible Context panel temporarily expands the target AI group to show the highlighted turn or tool, but it collapses again once the 2-second highlight fades. This makes it hard to inspect the content you just navigated to.

A new **"Keep expanded after context navigation"** toggle (Settings > General, off by default) calls `expandAIGroupForTab` alongside the highlight so the group stays open until manually collapsed.

## Changes

- Add `keepContextNavExpanded` to `DisplayConfig` with default `false`
- Wire the setting through config validation, safe config, and reset defaults
- In `ChatHistory`, read the flag during turn and tool navigation handlers and persist expansion when enabled
- Add toggle to General settings section using existing `onDisplayToggle` handler
- Update test mock with the new config key

## Test plan

- [ ] Toggle OFF (default): navigate from Visible Context panel — group expands briefly, collapses after highlight fades (existing behavior unchanged)
- [ ] Toggle ON: navigate from Visible Context panel — group stays expanded after highlight fades
- [ ] Toggle ON: navigate to a tool within an AI group — group stays expanded, tool is highlighted
- [ ] Setting persists after restarting the app
- [ ] Reset to defaults reverts the toggle to OFF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new display setting "Keep expanded after context navigation" in General settings. When enabled, AI groups remain expanded when navigating between turns and tools from the Visible Context panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->