### PR TITLE
fix(Docker): Add claude-devtools-config.json volume to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - "3456:3456"
     volumes:
       - ${CLAUDE_DIR:-~/.claude}:/data/.claude:ro
+      - ${CLAUDE_DIR:-~/.claude}/claude-devtools-config.json:/data/.claude/claude-devtools-config.json:rw
     environment:
       - NODE_ENV=production
       - CLAUDE_ROOT=/data/.claude


### PR DESCRIPTION
Fix for #178

When running claude-devtools in Docker, it's not possible to save the user config claude-devtools-config.json because of the read-only mount in docker-compose.yml:
```
[Service:ConfigManager] Error saving config: Error: EROFS: read-only file system, open '/data/.claude/claude-devtools-config.json'
```

This PR adds an exception read-write mount only on the claude-devtools config, so the user setting changes are persisted across container restarts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to support mounting configuration files with read-write permissions into the container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->