### PR TITLE
feat: add hover copy button to last output markdown

### DIFF
--- a/src/renderer/components/chat/LastOutputDisplay.tsx
+++ b/src/renderer/components/chat/LastOutputDisplay.tsx
@@ -88,7 +88,7 @@ export const LastOutputDisplay = ({
           border: '1px solid var(--code-border)',
         }}
       >
-        {/* Copy buttons are on individual code blocks via markdownComponents */}
+        <CopyButton text={textContent} />
 
         {/* Content - scrollable */}
         <div className="max-h-96 overflow-y-auto px-4 py-3" data-search-content>


### PR DESCRIPTION
The wrapper already had `group relative overflow-hidden` and matching `--code-bg`, so dropping in the existing overlay-mode CopyButton was a one-line change. Code blocks inside still keep their per-block copy buttons; this one copies the entire output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced copy functionality for text output by centralizing the copy button placement, ensuring consistent and reliable access to copy all text content in a single action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->