### PR TITLE
fix: prevent stale session detail and 60s update lag

### DIFF
--- a/src/main/ipc/sessions.ts
+++ b/src/main/ipc/sessions.ts
@@ -217,8 +217,20 @@ async function handleGetSessionDetail(
     const safeSessionId = validatedSession.value!;
     const cacheKey = DataCache.buildKey(safeProjectId, safeSessionId);
 
-    // Check cache first
-    let sessionDetail = dataCache.get(cacheKey);
+    // Stat the JSONL file so we can fingerprint the cache entry.
+    // Without this, a missed FileWatcher event leaves a stale cache entry
+    // that survives manual refresh for up to 10 minutes (the TTL).
+    let fingerprint: string | undefined;
+    try {
+      const filePath = projectScanner.getSessionPath(safeProjectId, safeSessionId);
+      const stats = await projectScanner.getFileSystemProvider().stat(filePath);
+      fingerprint = `${stats.mtimeMs}-${stats.size}`;
+    } catch {
+      // Stat failure is non-fatal — fall through to the existence check below.
+    }
+
+    // Check cache first (returns undefined if fingerprint mismatches)
+    let sessionDetail = dataCache.get(cacheKey, fingerprint);
 
     if (!sessionDetail) {
       const fsType = projectScanner.getFileSystemProvider().type;
@@ -246,8 +258,10 @@ async function handleGetSessionDetail(
       // Build session detail with chunks
       sessionDetail = chunkBuilder.buildSessionDetail(session, parsedSession.messages, subagents);
 
-      // Cache the result
-      dataCache.set(cacheKey, sessionDetail);
+      // Cache the result (paired with the fingerprint we observed pre-parse).
+      // If the file changed mid-parse, the next get() will see a newer mtime
+      // and re-fetch — at worst we serve one slightly-stale read.
+      dataCache.set(cacheKey, sessionDetail, fingerprint);
     }
 
     // Strip raw messages before IPC transfer — the renderer never uses them.

--- a/src/main/services/infrastructure/DataCache.ts
+++ b/src/main/services/infrastructure/DataCache.ts
@@ -18,6 +18,10 @@ interface CacheEntry<T> {
 
   timestamp: number;
   version: number; // Cache schema version
+  // Optional file-state fingerprint (e.g., `${mtimeMs}-${size}`).
+  // When present on both set() and get(), a mismatch invalidates the entry —
+  // a safety net for FileWatcher events dropped by macOS FSEvents.
+  fingerprint?: string;
 }
 
 // Union type for cached values
@@ -64,9 +68,11 @@ export class DataCache {
   /**
    * Gets a cached session detail.
    * @param key - Cache key in format "projectId/sessionId"
-   * @returns The cached SessionDetail, or undefined if not found or expired
+   * @param fingerprint - Optional file-state fingerprint. If the cached entry
+   *   has a fingerprint that differs from this one, it's treated as stale.
+   * @returns The cached SessionDetail, or undefined if not found, expired, or stale
    */
-  get(key: string): SessionDetail | undefined {
+  get(key: string, fingerprint?: string): SessionDetail | undefined {
     if (!this.enabled) {
       return undefined;
     }
@@ -87,6 +93,12 @@ export class DataCache {
     // Check if entry has expired
     const now = Date.now();
     if (now - entry.timestamp > this.ttl) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    // Check fingerprint mismatch (file changed since cached)
+    if (fingerprint !== undefined && entry.fingerprint !== fingerprint) {
       this.cache.delete(key);
       return undefined;
     }
@@ -141,7 +153,7 @@ export class DataCache {
    * Internal method to set a value in the cache.
    * Handles LRU eviction and cache entry creation.
    */
-  private setInternal(key: string, value: CachedValue): void {
+  private setInternal(key: string, value: CachedValue, fingerprint?: string): void {
     if (!this.enabled) {
       return;
     }
@@ -158,6 +170,7 @@ export class DataCache {
       value,
       timestamp: Date.now(),
       version: DataCache.CURRENT_VERSION,
+      fingerprint,
     });
   }
 
@@ -165,9 +178,11 @@ export class DataCache {
    * Sets a value in the cache.
    * @param key - Cache key in format "projectId/sessionId"
    * @param value - The SessionDetail to cache
+   * @param fingerprint - Optional file-state fingerprint paired with this entry.
+   *   When provided here AND on a future get(), a mismatch will invalidate.
    */
-  set(key: string, value: SessionDetail): void {
-    this.setInternal(key, value);
+  set(key: string, value: SessionDetail, fingerprint?: string): void {
+    this.setInternal(key, value, fingerprint);
   }
 
   /**

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -82,6 +82,7 @@ export function initializeNotificationListeners(): () => void {
     // Adaptive debounce: large sessions refresh less frequently to reduce memory churn.
     // Uses the TARGET session's cached totalAIGroups so a long session in another pane
     // doesn't force the active short session to the default interval.
+    // Capped at 5s so the UI never appears frozen for an actively-streaming session.
     const state = useStore.getState();
     const tabData = Object.values(state.tabSessionData).find(
       (td) => td?.sessionDetail?.session?.id === sessionId
@@ -90,15 +91,13 @@ export function initializeNotificationListeners(): () => void {
       tabData?.conversation?.totalAIGroups ??
       (state.conversation?.items ?? []).filter((i) => i.type === 'ai').length;
     const debounceMs =
-      aiGroupCount > 1000
-        ? 60000 // ~60s for very long sessions (24h+)
-        : aiGroupCount > 500
-          ? 30000 // ~30s for long sessions
-          : aiGroupCount > 200
-            ? 10000 // ~10s for medium sessions
-            : aiGroupCount > 100
-              ? 3000 // ~3s for moderate sessions
-              : SESSION_REFRESH_DEBOUNCE_MS; // 150ms default
+      aiGroupCount > 500
+        ? 5000 // 5s ceiling for very long sessions
+        : aiGroupCount > 200
+          ? 2500 // 2.5s for long sessions
+          : aiGroupCount > 100
+            ? 1000 // 1s for moderate sessions
+            : SESSION_REFRESH_DEBOUNCE_MS; // 150ms default
 
     const timer = setTimeout(() => {
       pendingSessionRefreshTimers.delete(key);


### PR DESCRIPTION
DataCache now stores an optional file-state fingerprint (mtimeMs+size) alongside each entry. handleGetSessionDetail stats the JSONL file before the cache lookup and passes the fingerprint to get()/set(); a mismatch invalidates the entry. This is a safety net for FileWatcher events dropped by macOS FSEvents — without it, a missed event left a stale cache entry that survived manual refresh for up to the 10-minute TTL.

Also caps the renderer's adaptive session-refresh debounce at 5s (previously up to 60s for sessions with >1000 AI groups), so the UI never appears frozen while a session is actively streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation to detect when session data has been modified on disk and properly refresh stale entries.

* **Performance**
  * Optimized session refresh timing to provide faster updates, with response times now capped at 5 seconds maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->