### PR TITLE
fix(MermaidViewer): clean up orphan error SVG left in document.body

### DIFF
--- a/src/renderer/components/chat/viewers/MermaidViewer.tsx
+++ b/src/renderer/components/chat/viewers/MermaidViewer.tsx
@@ -62,10 +62,19 @@ export const MermaidViewer: React.FC<MermaidViewerProps> = ({ code }) => {
   // Render mermaid diagram
   useEffect(() => {
     let cancelled = false;
+    const id = `mermaid-${uniqueId}`;
+
+    // Mermaid 在 render 失败时会把错误 SVG 残留在 document.body 下的 `d{id}` 包装 div 中
+    // （源码路径 mermaid.core.mjs 中 errorRenderer.draw 后直接 throw，跳过 removeTempElements 清理）
+    // 所以这里手动清理孤立节点，避免页面底部累积巨大的错误图标
+    const cleanupOrphans = (): void => {
+      document.getElementById(`d${id}`)?.remove();
+      document.getElementById(id)?.remove();
+    };
+
     const render = async (): Promise<void> => {
       try {
         const m = await ensureMermaidInit(isDark);
-        const id = `mermaid-${uniqueId}`;
         const { svg: rendered } = await m.render(id, code);
         if (!cancelled) {
           setSvg(rendered);
@@ -77,11 +86,14 @@ export const MermaidViewer: React.FC<MermaidViewerProps> = ({ code }) => {
           setError(err instanceof Error ? err.message : 'Failed to render mermaid diagram');
           setSvg('');
         }
+      } finally {
+        cleanupOrphans();
       }
     };
     void render();
     return () => {
       cancelled = true;
+      cleanupOrphans();
     };
   }, [code, isDark, uniqueId]);
 


### PR DESCRIPTION
When mermaid 11.13.0 fails to parse a diagram, errorRenderer.draw() paints a large error icon SVG into the temporary `d{id}` wrapper that mermaid appends to document.body, then immediately re-throws — skipping the trailing removeTempElements() call (mermaid.core.mjs:1078-1110). The orphan SVG (viewBox 0 0 2412 512) accumulates at the bottom of the page on every failed render.

<img width="2233" height="319" alt="image" src="https://github.com/user-attachments/assets/e9647ec1-be4b-41ec-a94c-00f431b42c51" />


Add a cleanupOrphans() helper in the render effect that removes the `d{id}` wrapper div and the `{id}` SVG node, invoked from a try/finally around mermaid.render() and from the effect cleanup. The component's own error UI is unchanged — failures still surface as a red banner with the original code inside the card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Mermaid diagram rendering failures could leave orphaned SVG elements on the page. Improved cleanup mechanisms now ensure these orphaned elements are properly removed, preventing performance degradation and maintaining a cleaner visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->