### PR TITLE
perf: short-circuit no-op session refreshes via fingerprint match

### DIFF
--- a/src/main/ipc/sessions.ts
+++ b/src/main/ipc/sessions.ts
@@ -17,7 +17,7 @@ import {
   type ConversationGroup,
   type PaginatedSessionsResult,
   type Session,
-  type SessionDetail,
+  type SessionDetailResponse,
   type SessionMetrics,
   type SessionsByIdsOptions,
   type SessionsPaginationOptions,
@@ -198,8 +198,9 @@ async function handleGetSessionsByIds(
 async function handleGetSessionDetail(
   _event: IpcMainInvokeEvent,
   projectId: string,
-  sessionId: string
-): Promise<SessionDetail | null> {
+  sessionId: string,
+  knownFingerprint?: string
+): Promise<SessionDetailResponse | null> {
   try {
     const validatedProject = validateProjectId(projectId);
     const validatedSession = validateSessionId(sessionId);
@@ -227,6 +228,20 @@ async function handleGetSessionDetail(
       fingerprint = `${stats.mtimeMs}-${stats.size}`;
     } catch {
       // Stat failure is non-fatal — fall through to the existence check below.
+    }
+
+    // Short-circuit: if the renderer's last-known fingerprint matches the
+    // current file state, skip cache lookup, parsing, and IPC payload entirely.
+    // This bounds the cost of frequent no-op refreshes (file-watcher noise,
+    // adaptive debounce on long sessions) to one stat() + a tiny sentinel.
+    // Only honored when the stat succeeded — a missing fingerprint means we
+    // can't prove the file is unchanged, so we fall through to the full path.
+    if (
+      knownFingerprint !== undefined &&
+      fingerprint !== undefined &&
+      knownFingerprint === fingerprint
+    ) {
+      return { unchanged: true, fingerprint };
     }
 
     // Check cache first (returns undefined if fingerprint mismatches)
@@ -267,10 +282,13 @@ async function handleGetSessionDetail(
     // Strip raw messages before IPC transfer — the renderer never uses them.
     // Only chunks (with semantic steps) and process summaries cross the boundary.
     // This cuts IPC serialization + renderer heap by ~50-60%.
+    // The fingerprint travels with the payload so the renderer can cache it
+    // and pass it back on the next refresh.
     return {
       ...sessionDetail,
       messages: [],
       processes: sessionDetail.processes.map((p) => ({ ...p, messages: [] })),
+      fingerprint,
     };
   } catch (error) {
     logger.error(`Error in get-session-detail for ${projectId}/${sessionId}:`, error);
@@ -368,8 +386,11 @@ async function handleGetWaterfallData(
   sessionId: string
 ): Promise<WaterfallData | null> {
   try {
+    // Waterfall always wants the full payload — no knownFingerprint passed,
+    // so an `unchanged` sentinel cannot be returned at runtime. The narrowing
+    // below is purely for type safety.
     const detail = await handleGetSessionDetail(_event, projectId, sessionId);
-    if (!detail) {
+    if (!detail || 'unchanged' in detail) {
       return null;
     }
 

--- a/src/main/types/chunks.ts
+++ b/src/main/types/chunks.ts
@@ -401,7 +401,33 @@ export interface SessionDetail {
   processes: Process[];
   /** Aggregated metrics for the entire session */
   metrics: SessionMetrics;
+  /**
+   * Opaque file-state fingerprint (mtimeMs+size) attached by the IPC handler.
+   * The renderer treats this as opaque — it's compared by string equality only,
+   * never parsed. Used to short-circuit `getSessionDetail` calls when the
+   * underlying file hasn't changed since the last successful fetch.
+   */
+  fingerprint?: string;
 }
+
+/**
+ * Sentinel response from `getSessionDetail` indicating the file is unchanged
+ * since the renderer's last fetch. Returned only when the caller passes a
+ * `knownFingerprint` that matches the current file state. Lets the renderer
+ * skip transformation and re-render entirely on no-op refreshes.
+ */
+export interface SessionDetailUnchanged {
+  unchanged: true;
+  fingerprint: string;
+}
+
+/**
+ * Discriminated union for `getSessionDetail` IPC responses.
+ * - `SessionDetail`: full payload (initial load OR file changed since last fetch)
+ * - `SessionDetailUnchanged`: file unchanged, renderer should no-op
+ * - `null`: error or session not found
+ */
+export type SessionDetailResponse = SessionDetail | SessionDetailUnchanged;
 
 /**
  * Detailed subagent information for drill-down modal.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -144,8 +144,8 @@ const electronAPI: ElectronAPI = {
   findSessionById: (sessionId: string) => ipcRenderer.invoke(FIND_SESSION_BY_ID, sessionId),
   findSessionsByPartialId: (fragment: string) =>
     ipcRenderer.invoke(FIND_SESSIONS_BY_PARTIAL_ID, fragment),
-  getSessionDetail: (projectId: string, sessionId: string) =>
-    ipcRenderer.invoke('get-session-detail', projectId, sessionId),
+  getSessionDetail: (projectId: string, sessionId: string, knownFingerprint?: string) =>
+    ipcRenderer.invoke('get-session-detail', projectId, sessionId, knownFingerprint),
   getSessionMetrics: (projectId: string, sessionId: string) =>
     ipcRenderer.invoke('get-session-metrics', projectId, sessionId),
   getWaterfallData: (projectId: string, sessionId: string) =>

--- a/src/renderer/components/layout/MoreMenu.tsx
+++ b/src/renderer/components/layout/MoreMenu.tsx
@@ -78,10 +78,14 @@ export const MoreMenu = ({
       setIsOpen(false);
       setExportLoading(true);
       // Re-fetch full detail (with chunks) since we strip them from the store to save memory.
+      // No knownFingerprint passed, so the response is always SessionDetail | null
+      // at runtime. Narrow defensively for type safety.
       void api
         .getSessionDetail(projectId, sessionId)
-        .then((detail) => {
-          if (detail) triggerDownload(detail, format);
+        .then((response) => {
+          if (response && !('unchanged' in response)) {
+            triggerDownload(response, format);
+          }
         })
         .finally(() => {
           setExportLoading(false);

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -79,10 +79,15 @@ export function initializeNotificationListeners(): () => void {
       return;
     }
 
-    // Adaptive debounce: large sessions refresh less frequently to reduce memory churn.
-    // Uses the TARGET session's cached totalAIGroups so a long session in another pane
-    // doesn't force the active short session to the default interval.
-    // Capped at 5s so the UI never appears frozen for an actively-streaming session.
+    // Adaptive debounce: large sessions refresh less frequently to coalesce
+    // burst file-change events and amortize React re-render cost over a wider
+    // window. Uses the TARGET session's cached totalAIGroups so a long session
+    // in another pane doesn't force the active short session to the default.
+    //
+    // The IPC handler short-circuits no-op refreshes via fingerprint matching,
+    // so frequent refreshes are cheap when nothing changed. These values are
+    // tuned for the cost of a *real* update (incremental transform + zustand
+    // setState + re-render), not for raw call frequency.
     const state = useStore.getState();
     const tabData = Object.values(state.tabSessionData).find(
       (td) => td?.sessionDetail?.session?.id === sessionId
@@ -92,11 +97,11 @@ export function initializeNotificationListeners(): () => void {
       (state.conversation?.items ?? []).filter((i) => i.type === 'ai').length;
     const debounceMs =
       aiGroupCount > 500
-        ? 5000 // 5s ceiling for very long sessions
+        ? 1000 // 1s ceiling for very long sessions
         : aiGroupCount > 200
-          ? 2500 // 2.5s for long sessions
+          ? 500 // 500ms for long sessions
           : aiGroupCount > 100
-            ? 1000 // 1s for moderate sessions
+            ? 300 // 300ms for moderate sessions
             : SESSION_REFRESH_DEBOUNCE_MS; // 150ms default
 
     const timer = setTimeout(() => {

--- a/src/renderer/store/slices/sessionDetailSlice.ts
+++ b/src/renderer/store/slices/sessionDetailSlice.ts
@@ -13,6 +13,7 @@ import {
   transformChunksToConversation,
 } from '@renderer/utils/groupTransformer';
 import { createLogger } from '@shared/utils/logger';
+import { isSessionDetailUnchanged } from '@shared/utils/sessionDetailResponse';
 
 import { batchAsync } from '../utils/batchAsync';
 import { resolveFilePath } from '../utils/pathResolution';
@@ -31,6 +32,14 @@ const sessionRefreshQueued = new Set<string>();
  * When unchanged, the refresh can skip the expensive transformation entirely.
  */
 const sessionChunkFingerprint = new Map<string, string>();
+/**
+ * Opaque file-state fingerprint (mtimeMs+size) reported by the IPC handler.
+ * Passed back on the next `getSessionDetail` call so main can short-circuit
+ * with an `unchanged` sentinel — saving full session-detail serialization
+ * on every no-op refresh. Distinct from `sessionChunkFingerprint`, which is
+ * a renderer-local content fingerprint used as a second-line guard.
+ */
+const sessionFileFingerprint = new Map<string, string>();
 let sessionDetailFetchGeneration = 0;
 let agentConfigsCachedForProject = '';
 
@@ -178,9 +187,19 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
       });
     }
     try {
-      const detail = await api.getSessionDetail(projectId, sessionId);
+      // Initial load — never pass knownFingerprint, so an `unchanged` sentinel
+      // cannot be returned at runtime. Narrow defensively for type safety.
+      const response = await api.getSessionDetail(projectId, sessionId);
       if (requestGeneration !== sessionDetailFetchGeneration) {
         return;
+      }
+      const detail = response && !isSessionDetailUnchanged(response) ? response : null;
+
+      // Capture file fingerprint so future refreshes can short-circuit when
+      // the file is unchanged.
+      const refreshKey = `${projectId}/${sessionId}`;
+      if (detail?.fingerprint) {
+        sessionFileFingerprint.set(refreshKey, detail.fingerprint);
       }
 
       // Transform chunks to conversation
@@ -547,15 +566,33 @@ export const createSessionDetailSlice: StateCreator<AppState, [], [], SessionDet
     sessionRefreshInFlight.add(refreshKey);
 
     try {
-      const detail = await api.getSessionDetail(projectId, sessionId);
+      // Pass the last-known file fingerprint so main can short-circuit when
+      // the file hasn't changed. This is the primary fix for the perf
+      // regression where rapid refreshes paid full IPC + transformation cost
+      // even when nothing on disk had changed.
+      const knownFingerprint = sessionFileFingerprint.get(refreshKey);
+      const response = await api.getSessionDetail(projectId, sessionId, knownFingerprint);
 
       // Drop stale responses if a newer refresh started while this one was in flight.
       if (sessionRefreshGeneration.get(refreshKey) !== generation) {
         return;
       }
 
-      if (!detail) {
+      if (!response) {
         return;
+      }
+
+      // Fast path: main confirmed the file is unchanged. No transformation,
+      // no setState, no re-render. Cost is bounded to one stat() + tiny IPC.
+      if (isSessionDetailUnchanged(response)) {
+        return;
+      }
+
+      const detail = response;
+
+      // Update the file fingerprint cache so the next refresh can short-circuit.
+      if (detail.fingerprint) {
+        sessionFileFingerprint.set(refreshKey, detail.fingerprint);
       }
 
       // Transform chunks to conversation - validate with type guard

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -24,7 +24,7 @@ import type {
   RepositoryGroup,
   SearchSessionsResult,
   Session,
-  SessionDetail,
+  SessionDetailResponse,
   SessionMetrics,
   SessionsByIdsOptions,
   SessionsPaginationOptions,
@@ -341,7 +341,22 @@ export interface ElectronAPI {
   searchAllProjects: (query: string, maxResults?: number) => Promise<SearchSessionsResult>;
   findSessionById: (sessionId: string) => Promise<FindSessionByIdResult>;
   findSessionsByPartialId: (fragment: string) => Promise<FindSessionsByPartialIdResult>;
-  getSessionDetail: (projectId: string, sessionId: string) => Promise<SessionDetail | null>;
+  /**
+   * Fetch full session detail.
+   *
+   * When `knownFingerprint` is provided and matches the current file state,
+   * returns a lightweight `{ unchanged: true, fingerprint }` sentinel instead
+   * of the full payload. This lets `refreshSessionInPlace` short-circuit
+   * no-op refreshes without paying IPC serialization cost.
+   *
+   * Initial loads (no `knownFingerprint`) always receive a full SessionDetail
+   * (or null on error/not-found), preserving backwards-compatible behavior.
+   */
+  getSessionDetail: (
+    projectId: string,
+    sessionId: string,
+    knownFingerprint?: string
+  ) => Promise<SessionDetailResponse | null>;
   getSessionMetrics: (projectId: string, sessionId: string) => Promise<SessionMetrics | null>;
   getWaterfallData: (projectId: string, sessionId: string) => Promise<WaterfallData | null>;
   getSubagentDetail: (

--- a/src/shared/utils/sessionDetailResponse.ts
+++ b/src/shared/utils/sessionDetailResponse.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for the `getSessionDetail` IPC contract.
+ *
+ * The handler can return either a full `SessionDetail` or a lightweight
+ * `SessionDetailUnchanged` sentinel when the renderer's cached fingerprint
+ * matches the file on disk. The sentinel lets the renderer skip
+ * transformation and re-render entirely on no-op refreshes.
+ *
+ * Lives in `shared/` so the wire format stays in one place — if anyone
+ * changes the discriminator, this is the file (and its test) they touch.
+ */
+
+import type { SessionDetail, SessionDetailUnchanged } from '@main/types';
+
+/**
+ * Type guard for the `unchanged` IPC sentinel.
+ *
+ * Discriminates on the literal `unchanged: true` flag. `SessionDetail` has
+ * no such field, so a present `unchanged` uniquely identifies the sentinel.
+ */
+export function isSessionDetailUnchanged(
+  response: SessionDetail | SessionDetailUnchanged | null | undefined
+): response is SessionDetailUnchanged {
+  return (
+    !!response &&
+    typeof response === 'object' &&
+    'unchanged' in response &&
+    (response as { unchanged: unknown }).unchanged === true
+  );
+}

--- a/test/shared/utils/sessionDetailResponse.test.ts
+++ b/test/shared/utils/sessionDetailResponse.test.ts
@@ -1,0 +1,63 @@
+/**
+ * IPC contract tests for `getSessionDetail` response shape.
+ *
+ * These tests guard the wire format between the renderer and main process.
+ * If `isSessionDetailUnchanged` ever stops correctly identifying the sentinel,
+ * `refreshSessionInPlace` will fall through to the full transform path on
+ * every no-op refresh — restoring the v0.4.13 perf regression. That's the
+ * scenario this test exists to prevent.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isSessionDetailUnchanged } from '../../../src/shared/utils/sessionDetailResponse';
+
+import type { SessionDetail } from '../../../src/main/types';
+
+describe('isSessionDetailUnchanged', () => {
+  it('returns true for the unchanged sentinel', () => {
+    expect(isSessionDetailUnchanged({ unchanged: true, fingerprint: '12345-67890' })).toBe(true);
+  });
+
+  it('returns false for a full SessionDetail (no unchanged field)', () => {
+    const detail = {
+      session: {} as never,
+      messages: [],
+      chunks: [],
+      processes: [],
+      metrics: {} as never,
+      fingerprint: '12345-67890',
+    } as SessionDetail;
+
+    expect(isSessionDetailUnchanged(detail)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isSessionDetailUnchanged(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isSessionDetailUnchanged(undefined)).toBe(false);
+  });
+
+  it('returns false when unchanged is not literal true (defense-in-depth)', () => {
+    // Any non-true value should not be treated as unchanged. Guards against a
+    // future refactor that accidentally serializes a falsy/truthy variant.
+    expect(isSessionDetailUnchanged({ unchanged: false } as never)).toBe(false);
+    expect(isSessionDetailUnchanged({ unchanged: 1 } as never)).toBe(false);
+    expect(isSessionDetailUnchanged({ unchanged: 'yes' } as never)).toBe(false);
+  });
+
+  it('narrows the type so callers can access fingerprint', () => {
+    const response: SessionDetail | { unchanged: true; fingerprint: string } = {
+      unchanged: true,
+      fingerprint: 'abc-123',
+    };
+    if (isSessionDetailUnchanged(response)) {
+      // Type narrowing: response.fingerprint is now string, not optional.
+      expect(response.fingerprint).toBe('abc-123');
+    } else {
+      throw new Error('expected unchanged sentinel');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #186. Long sessions ran at ~10fps after v0.4.13 because PR #183 shrank the refresh debounce ceiling from 60s to 5s. The shorter window exposed an existing architectural flaw: every `getSessionDetail` IPC returned the full payload, with the renderer-side fingerprint check happening *after* the expensive serialization. Frequent refreshes paid near-real-refresh cost even when nothing on disk had changed.

Move the fingerprint check to the IPC boundary. The renderer caches the opaque file-state fingerprint (mtimeMs+size) returned by main and passes it back on the next call. When it matches, the handler short-circuits to a tiny `{ unchanged: true }` sentinel before cache lookup or parsing. The renderer detects the sentinel and exits without transforming or re-rendering — bounded to one stat() + a sub-100B IPC payload.

With no-op cost effectively eliminated, the adaptive debounce can be restored to sane values (1s ceiling for >500 groups, 500ms for >200, 300ms for >100), preserving the streaming-responsiveness intent of PR #183 without the perf cost.

Backwards compatible: knownFingerprint is optional, so initial loads and export still receive a full SessionDetail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Session refresh now intelligently detects unchanged file state and skips redundant updates, reducing processing overhead
  * Adaptive refresh timing optimized for sessions with large datasets, increasing update frequency while maintaining smooth performance

* **Bug Fixes**
  * Enhanced robustness in handling concurrent session refresh operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->