### PR TITLE
fix(release): correct arch routing for macOS dmg + in-app updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,17 +49,13 @@ jobs:
 
   release-mac:
     needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: arm64
-            runner: macos-14
-            dist_command: pnpm dist:mac:arm64
-          - arch: x64
-            runner: macos-15-intel
-            dist_command: pnpm dist:mac:x64
-    runs-on: ${{ matrix.runner }}
+    # Single job builds BOTH arm64 and x64 in one electron-builder invocation.
+    # Reason: when arches are split into separate jobs each running `--publish always`,
+    # each upload OVERWRITES latest-mac.yml — so the final yml only lists one arch
+    # and electron-updater silently routes the wrong-arch dmg to users (arm64 users
+    # get x64 → Rosetta penalty). Building both in one invocation produces a single
+    # latest-mac.yml that lists both arches, so auto-update routes correctly.
+    runs-on: macos-14   # arm64 runner; macOS supports x64 cross-build natively
 
     steps:
       - name: Checkout
@@ -93,16 +89,16 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
           pnpm pkg set version="$VERSION"
 
-      - name: Build app (macOS ${{ matrix.arch }})
+      - name: Build app
         run: pnpm build
 
-      - name: Verify packaged inputs (macOS ${{ matrix.arch }})
+      - name: Verify packaged inputs
         run: |
           test -f dist-electron/main/index.cjs
           test -f dist-electron/preload/index.js
           test -f out/renderer/index.html
 
-      - name: Package & Release (macOS ${{ matrix.arch }})
+      - name: Package & Release (macOS arm64 + x64)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -110,7 +106,65 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: ${{ matrix.dist_command }}
+        run: pnpm dist:mac
+
+      - name: Assert arch suffix in artifact names
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          BAD=()
+          for f in release/*.dmg release/*.zip; do
+            base=$(basename "$f")
+            case "$base" in
+              *blockmap*|*-arm64.dmg|*-arm64.zip|*-arm64-mac.zip|*-x64.dmg|*-x64.zip|*-x64-mac.zip)
+                ;;
+              *)
+                BAD+=("$base")
+                ;;
+            esac
+          done
+          if [ ${#BAD[@]} -gt 0 ]; then
+            echo "::error::Found macOS artifacts without '-arm64' or '-x64' suffix. Apple Silicon users would download x64 by default and run under Rosetta. Fix package.json build.mac.artifactName."
+            printf '  bad: %s\n' "${BAD[@]}"
+            exit 1
+          fi
+          echo "OK: all macOS artifacts have arch suffix"
+          ls -la release/ | grep -E '\.(dmg|zip)$' || true
+
+      - name: Verify latest-mac.yml lists BOTH arm64 and x64
+        run: |
+          set -euo pipefail
+          YML=release/latest-mac.yml
+          test -f "$YML" || { echo "::error::missing $YML — electron-updater cannot route auto-updates"; exit 1; }
+          echo "--- latest-mac.yml ---"
+          cat "$YML"
+          echo "----------------------"
+          # Both arches must appear in the yml, otherwise electron-updater will route
+          # the wrong dmg to one arch's users (the regression that caused #186).
+          grep -q -- '-arm64\.dmg' "$YML" || { echo "::error::latest-mac.yml missing arm64 dmg entry — arm64 users will receive x64 build"; exit 1; }
+          grep -q -- '-x64\.dmg'   "$YML" || { echo "::error::latest-mac.yml missing x64 dmg entry — x64 users will receive arm64 build"; exit 1; }
+          echo "OK: latest-mac.yml lists both arm64 and x64"
+
+      - name: Verify each dmg's binary matches its arch suffix
+        run: |
+          set -euo pipefail
+          fail=0
+          for dmg in release/*-arm64.dmg release/*-x64.dmg; do
+            [ -e "$dmg" ] || continue
+            expected=$([[ "$dmg" == *"-arm64.dmg" ]] && echo arm64 || echo x86_64)
+            mount=$(hdiutil attach "$dmg" -nobrowse -readonly | tail -1 | awk '{print $NF}')
+            bin="$mount/claude-devtools.app/Contents/MacOS/claude-devtools"
+            if [ -f "$bin" ]; then
+              actual=$(file "$bin")
+              echo "$dmg -> $actual"
+              echo "$actual" | grep -q "$expected" || { echo "::error::$dmg has wrong binary arch (expected $expected)"; fail=1; }
+            else
+              echo "::warning::no binary at $bin"
+            fi
+            hdiutil detach "$mount" -quiet || true
+          done
+          [ "$fail" = 0 ] || exit 1
+          echo "OK: each dmg's binary matches its arch suffix"
 
   release-win:
     needs: build

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "dist": "electron-builder --mac --win --linux",
-    "dist:mac": "electron-builder --mac --publish always",
+    "dist:mac": "electron-builder --mac --arm64 --x64 --publish always",
     "dist:mac:arm64": "electron-builder --mac --arm64 --publish always",
     "dist:mac:x64": "electron-builder --mac --x64 --publish always",
     "dist:win": "electron-builder --win --publish always",
@@ -138,6 +138,7 @@
         "dmg",
         "zip"
       ],
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": true,
@@ -152,6 +153,7 @@
       "target": [
         "nsis"
       ],
+      "artifactName": "${productName}-Setup-${version}-${arch}.${ext}",
       "icon": "resources/icons/win/icon.ico"
     },
     "linux": {
@@ -161,6 +163,7 @@
         "rpm",
         "pacman"
       ],
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
       "icon": "resources/icons/png",
       "category": "Development"
     },


### PR DESCRIPTION
Apple Silicon users were silently downloading the x64 build and running under Rosetta. Two compounding bugs:

1. **Filename collision in defaults.** electron-builder's default artifactName omits the arch suffix for x64, producing `claude-devtools-VERSION.dmg` (x64) alongside `claude-devtools-VERSION-arm64.dmg`. The unsuffixed file looks like the canonical download, and most arm64 users picked it. `file` on the installed binary confirms `Mach-O 64-bit executable x86_64` on M-series Macs — Rosetta translation explains the 11x page-ins, 6.7x mach syscalls, and 16% idle CPU we measured against `pnpm dev`.

2. **latest-mac.yml overwrite.** The release workflow built arm64 and x64 in separate matrix jobs, each running `electron-builder --publish always`. Each upload OVERWROTE latest-mac.yml — the final yml only listed one arch. electron-updater (in-app auto-update) then routed the wrong dmg to the other arch's users, perpetuating the Rosetta install via auto-update.

Fix:
- `package.json`: force `${arch}` in artifactName for mac/win/linux so every artifact has an unambiguous suffix (`-arm64`, `-x64`).
- `package.json`: `dist:mac` now builds both arches in one electron-builder invocation. A single invocation produces a single latest-mac.yml that lists both.
- `.github/workflows/release.yml`: collapse the macOS matrix into a single job on macos-14 (arm64 cross-builds x64 natively on macOS).
- Add three release-blocking assertions:
  - every dmg/zip has `-arm64` or `-x64` suffix,
  - latest-mac.yml lists BOTH arches,
  - each dmg's binary actually matches its arch suffix (mount + file).

Existing arm64 users on the Rosetta x64 build will be auto-corrected on the next in-app update once latest-mac.yml routes properly.

Note: the Homebrew cask URL template will need a manual PR after the next release — \`arch arm: \"-arm64\", intel: \"-x64\"\` so intel users hit the new \`-x64\`-suffixed dmg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined macOS build workflow to generate both ARM64 and x64 architectures in a single job
  * Added validation to verify correct architecture binaries are produced
  * Updated artifact naming convention for macOS, Windows, and Linux releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->