### PR TITLE
fix(discovery): list sessions from git worktrees

### DIFF
--- a/src/main/services/parsing/GitIdentityResolver.ts
+++ b/src/main/services/parsing/GitIdentityResolver.ts
@@ -447,7 +447,7 @@ class GitIdentityResolver {
       const gitInfo = await this.findGitPath(projectPath);
       if (!gitInfo) return null;
 
-      const { gitPath, stats } = gitInfo;
+      const { repoRoot, gitPath, stats } = gitInfo;
       let headPath: string;
 
       if (stats.isFile()) {
@@ -459,7 +459,12 @@ class GitIdentityResolver {
           return null;
         }
 
-        headPath = path.join(gitDirMatch[1], 'HEAD');
+        let worktreeGitDir = gitDirMatch[1].trim();
+        if (!path.isAbsolute(worktreeGitDir)) {
+          worktreeGitDir = path.resolve(repoRoot, worktreeGitDir);
+        }
+
+        headPath = path.join(worktreeGitDir, 'HEAD');
       } else {
         // Main repo
         headPath = path.join(gitPath, 'HEAD');

--- a/src/main/services/parsing/GitIdentityResolver.ts
+++ b/src/main/services/parsing/GitIdentityResolver.ts
@@ -34,6 +34,36 @@ const logger = createLogger('Service:GitIdentityResolver');
 
 class GitIdentityResolver {
   /**
+   * Helper to find the nearest .git file or directory by searching upwards.
+   */
+  private async findGitPath(projectPath: string): Promise<{ repoRoot: string; gitPath: string; stats: fs.Stats } | null> {
+    try {
+      let currentPath = path.resolve(projectPath);
+
+      while (currentPath) {
+        const gitPath = path.join(currentPath, '.git');
+        try {
+          const stats = await fs.promises.stat(gitPath);
+          if (stats.isFile() || stats.isDirectory()) {
+            return { repoRoot: currentPath, gitPath, stats };
+          }
+        } catch {
+          // Ignore and continue upward
+        }
+        
+        const parentDir = path.dirname(currentPath);
+        if (parentDir === currentPath) {
+          break;
+        }
+        currentPath = parentDir;
+      }
+    } catch {
+      // Ignore resolving errors
+    }
+    return null;
+  }
+
+  /**
    * Resolve repository identity from a project path.
    *
    * Algorithm:
@@ -49,15 +79,24 @@ class GitIdentityResolver {
    */
   async resolveIdentity(projectPath: string): Promise<RepositoryIdentity | null> {
     try {
-      const gitPath = path.join(projectPath, '.git');
-
-      // First, try filesystem-based resolution
+      // Search upwards for .git
+      let currentPath = projectPath;
       let gitPathExists = false;
-      try {
-        await fs.promises.access(gitPath);
-        gitPathExists = true;
-      } catch {
-        // Path doesn't exist
+      let gitPath = '';
+
+      while (currentPath) {
+        gitPath = path.join(currentPath, '.git');
+        try {
+          await fs.promises.access(gitPath);
+          gitPathExists = true;
+          break; // Found it
+        } catch {
+          const parentDir = path.dirname(currentPath);
+          if (parentDir === currentPath) {
+            break;
+          }
+          currentPath = parentDir;
+        }
       }
 
       if (gitPathExists) {
@@ -79,7 +118,7 @@ class GitIdentityResolver {
 
           // Handle relative paths in gitdir (resolve relative to the .git file location)
           if (!path.isAbsolute(worktreeGitDir)) {
-            worktreeGitDir = path.resolve(projectPath, worktreeGitDir);
+            worktreeGitDir = path.resolve(currentPath, worktreeGitDir);
           }
 
           mainGitDir = this.extractMainGitDir(worktreeGitDir);
@@ -264,12 +303,9 @@ class GitIdentityResolver {
 
     // Fallback: check filesystem if available
     try {
-      const gitPath = path.join(projectPath, '.git');
-      try {
-        const stats = await fs.promises.stat(gitPath);
-        return stats.isFile();
-      } catch {
-        // Path doesn't exist
+      const gitInfo = await this.findGitPath(projectPath);
+      if (gitInfo) {
+        return gitInfo.stats.isFile();
       }
     } catch {
       // Ignore errors - filesystem might not be available
@@ -426,13 +462,26 @@ class GitIdentityResolver {
    */
   async getBranch(projectPath: string): Promise<string | null> {
     try {
-      const gitPath = path.join(projectPath, '.git');
+      let currentPath = projectPath;
+      let gitPathExists = false;
+      let gitPath = '';
 
-      try {
-        await fs.promises.access(gitPath);
-      } catch {
-        return null;
+      while (currentPath) {
+        gitPath = path.join(currentPath, '.git');
+        try {
+          await fs.promises.access(gitPath);
+          gitPathExists = true;
+          break; // Found it
+        } catch {
+          const parentDir = path.dirname(currentPath);
+          if (parentDir === currentPath) {
+            break;
+          }
+          currentPath = parentDir;
+        }
       }
+
+      if (!gitPathExists) return null;
 
       const stats = await fs.promises.stat(gitPath);
       let headPath: string;
@@ -535,12 +584,19 @@ class GitIdentityResolver {
     // Check if it's a standard git repo (only if filesystem exists)
     // For deleted repos, we'll return 'git' as fallback since we can't verify
     try {
-      const gitPath = path.join(projectPath, '.git');
-      try {
-        await fs.promises.access(gitPath);
-        return 'git';
-      } catch {
-        // Path doesn't exist
+      let currentPath = projectPath;
+      while (currentPath) {
+        const gitPath = path.join(currentPath, '.git');
+        try {
+          await fs.promises.access(gitPath);
+          return 'git';
+        } catch {
+          const parentDir = path.dirname(currentPath);
+          if (parentDir === currentPath) {
+            break;
+          }
+          currentPath = parentDir;
+        }
       }
     } catch {
       // Ignore errors - filesystem might not be available
@@ -666,21 +722,24 @@ class GitIdentityResolver {
    */
   private async getGitWorktreeName(projectPath: string): Promise<string | null> {
     try {
-      const gitPath = path.join(projectPath, '.git');
-      let stats: fs.Stats;
-      try {
-        stats = await fs.promises.stat(gitPath);
-      } catch {
-        return null;
-      }
-      if (!stats.isFile()) return null;
+      const gitInfo = await this.findGitPath(projectPath);
+      
+      if (!gitInfo) return null;
+      if (!gitInfo.stats.isFile()) return null;
+
+      const { repoRoot, gitPath } = gitInfo;
 
       const content = await fs.promises.readFile(gitPath, 'utf-8');
       const match = /gitdir:\s*(\S[^\r\n]*)/.exec(content);
       if (!match) return null;
 
+      let worktreeGitDir = match[1].trim();
+      if (!path.isAbsolute(worktreeGitDir)) {
+        worktreeGitDir = path.resolve(repoRoot, worktreeGitDir);
+      }
+
       // gitdir: /main/.git/worktrees/my-worktree-name
-      const gitdirParts = match[1].trim().split(path.sep);
+      const gitdirParts = worktreeGitDir.split(path.sep);
       const worktreesIdx = gitdirParts.lastIndexOf(WORKTREES_DIR);
       if (worktreesIdx >= 0 && gitdirParts[worktreesIdx + 1]) {
         return gitdirParts[worktreesIdx + 1];

--- a/src/main/services/parsing/GitIdentityResolver.ts
+++ b/src/main/services/parsing/GitIdentityResolver.ts
@@ -79,28 +79,10 @@ class GitIdentityResolver {
    */
   async resolveIdentity(projectPath: string): Promise<RepositoryIdentity | null> {
     try {
-      // Search upwards for .git
-      let currentPath = projectPath;
-      let gitPathExists = false;
-      let gitPath = '';
+      const gitInfo = await this.findGitPath(projectPath);
 
-      while (currentPath) {
-        gitPath = path.join(currentPath, '.git');
-        try {
-          await fs.promises.access(gitPath);
-          gitPathExists = true;
-          break; // Found it
-        } catch {
-          const parentDir = path.dirname(currentPath);
-          if (parentDir === currentPath) {
-            break;
-          }
-          currentPath = parentDir;
-        }
-      }
-
-      if (gitPathExists) {
-        const stats = await fs.promises.stat(gitPath);
+      if (gitInfo) {
+        const { repoRoot: currentPath, gitPath, stats } = gitInfo;
 
         let mainGitDir: string;
 
@@ -462,28 +444,10 @@ class GitIdentityResolver {
    */
   async getBranch(projectPath: string): Promise<string | null> {
     try {
-      let currentPath = projectPath;
-      let gitPathExists = false;
-      let gitPath = '';
+      const gitInfo = await this.findGitPath(projectPath);
+      if (!gitInfo) return null;
 
-      while (currentPath) {
-        gitPath = path.join(currentPath, '.git');
-        try {
-          await fs.promises.access(gitPath);
-          gitPathExists = true;
-          break; // Found it
-        } catch {
-          const parentDir = path.dirname(currentPath);
-          if (parentDir === currentPath) {
-            break;
-          }
-          currentPath = parentDir;
-        }
-      }
-
-      if (!gitPathExists) return null;
-
-      const stats = await fs.promises.stat(gitPath);
+      const { gitPath, stats } = gitInfo;
       let headPath: string;
 
       if (stats.isFile()) {
@@ -584,19 +548,9 @@ class GitIdentityResolver {
     // Check if it's a standard git repo (only if filesystem exists)
     // For deleted repos, we'll return 'git' as fallback since we can't verify
     try {
-      let currentPath = projectPath;
-      while (currentPath) {
-        const gitPath = path.join(currentPath, '.git');
-        try {
-          await fs.promises.access(gitPath);
-          return 'git';
-        } catch {
-          const parentDir = path.dirname(currentPath);
-          if (parentDir === currentPath) {
-            break;
-          }
-          currentPath = parentDir;
-        }
+      const gitInfo = await this.findGitPath(projectPath);
+      if (gitInfo) {
+        return 'git';
       }
     } catch {
       // Ignore errors - filesystem might not be available

--- a/test/main/services/discovery/WorktreeGrouper.test.ts
+++ b/test/main/services/discovery/WorktreeGrouper.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { WorktreeGrouper } from '@main/services/discovery/WorktreeGrouper';
+import { LocalFileSystemProvider } from '@main/services/infrastructure/LocalFileSystemProvider';
+import { Project } from '@main/types';
+import { gitIdentityResolver } from '@main/services/parsing/GitIdentityResolver';
+
+describe('WorktreeGrouper', () => {
+  let tmpDir: string;
+  let mainRepoDir: string;
+  let worktreeDir: string;
+  let projectsDir: string;
+  let grouper: WorktreeGrouper;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-grouper-test-'));
+    mainRepoDir = path.join(tmpDir, 'main-repo');
+    worktreeDir = path.join(tmpDir, 'my-worktree');
+    projectsDir = path.join(tmpDir, 'projects');
+
+    fs.mkdirSync(mainRepoDir);
+    fs.mkdirSync(path.join(mainRepoDir, '.git'));
+    fs.mkdirSync(path.join(mainRepoDir, '.git', 'worktrees'));
+    fs.mkdirSync(path.join(mainRepoDir, '.git', 'worktrees', 'my-worktree'));
+
+    fs.writeFileSync(
+      path.join(mainRepoDir, '.git', 'config'),
+      '[remote "origin"]\n\turl = git@github.com:matt1398/claude-devtools.git\n'
+    );
+
+    fs.mkdirSync(worktreeDir);
+    fs.writeFileSync(
+      path.join(worktreeDir, '.git'),
+      `gitdir: ${path.join(mainRepoDir, '.git', 'worktrees', 'my-worktree')}\n`
+    );
+
+    fs.mkdirSync(projectsDir);
+
+    grouper = new WorktreeGrouper(projectsDir, new LocalFileSystemProvider());
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('groups main repo and worktree together', async () => {
+    // Mock the SubprojectRegistry so it returns no session filter, which allows all sessions
+    vi.mock('@main/services/discovery/SubprojectRegistry', () => ({
+      subprojectRegistry: {
+        getSessionFilter: () => null,
+      },
+    }));
+
+    // Mock SessionContentFilter to always return true (not noise)
+    vi.mock('@main/services/discovery/SessionContentFilter', () => ({
+      SessionContentFilter: {
+        hasNonNoiseMessages: vi.fn().mockResolvedValue(true),
+      },
+    }));
+
+    const projects: Project[] = [
+      {
+        id: 'main-repo-id',
+        path: mainRepoDir,
+        name: 'main-repo',
+        sessions: ['session1'],
+        createdAt: 1000,
+        mostRecentSession: 2000,
+      },
+      {
+        id: 'worktree-id',
+        path: worktreeDir,
+        name: 'my-worktree',
+        sessions: ['session2'],
+        createdAt: 1500,
+        mostRecentSession: 2500,
+      },
+    ];
+
+    const groups = await grouper.groupByRepository(projects);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].worktrees).toHaveLength(2);
+    expect(groups[0].worktrees.find(w => w.isMainWorktree)?.path).toBe(mainRepoDir);
+    expect(groups[0].worktrees.find(w => !w.isMainWorktree)?.path).toBe(worktreeDir);
+  });
+});

--- a/test/main/services/parsing/GitIdentityResolver.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.test.ts
@@ -9,8 +9,8 @@ describe('GitIdentityResolver', () => {
   let mainRepoDir: string;
   let worktreeDir: string;
 
-  beforeEach(() => {
-    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'git-identity-test-')));
+  beforeEach(async () => {
+    tmpDir = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'git-identity-test-')));
     mainRepoDir = path.join(tmpDir, 'main-repo');
     worktreeDir = path.join(tmpDir, 'my-worktree');
 
@@ -38,14 +38,14 @@ describe('GitIdentityResolver', () => {
   it('resolves identity for main repo', async () => {
     const identity = await gitIdentityResolver.resolveIdentity(mainRepoDir);
     expect(identity).toBeDefined();
-    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.mainGitDir).toBe(await fs.promises.realpath(path.join(mainRepoDir, '.git')));
     expect(identity?.name).toBe('main-repo');
   });
 
   it('resolves identity for worktree', async () => {
     const identity = await gitIdentityResolver.resolveIdentity(worktreeDir);
     expect(identity).toBeDefined();
-    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.mainGitDir).toBe(await fs.promises.realpath(path.join(mainRepoDir, '.git')));
     expect(identity?.name).toBe('main-repo');
   });
 });

--- a/test/main/services/parsing/GitIdentityResolver.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.test.ts
@@ -10,7 +10,7 @@ describe('GitIdentityResolver', () => {
   let worktreeDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-identity-test-'));
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'git-identity-test-')));
     mainRepoDir = path.join(tmpDir, 'main-repo');
     worktreeDir = path.join(tmpDir, 'my-worktree');
 

--- a/test/main/services/parsing/GitIdentityResolver.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { gitIdentityResolver } from '@main/services/parsing/GitIdentityResolver';
+
+describe('GitIdentityResolver', () => {
+  let tmpDir: string;
+  let mainRepoDir: string;
+  let worktreeDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-identity-test-'));
+    mainRepoDir = path.join(tmpDir, 'main-repo');
+    worktreeDir = path.join(tmpDir, 'my-worktree');
+
+    fs.mkdirSync(mainRepoDir);
+    fs.mkdirSync(path.join(mainRepoDir, '.git'));
+    fs.mkdirSync(path.join(mainRepoDir, '.git', 'worktrees'));
+    fs.mkdirSync(path.join(mainRepoDir, '.git', 'worktrees', 'my-worktree'));
+
+    fs.writeFileSync(
+      path.join(mainRepoDir, '.git', 'config'),
+      '[remote "origin"]\n\turl = git@github.com:matt1398/claude-devtools.git\n'
+    );
+
+    fs.mkdirSync(worktreeDir);
+    fs.writeFileSync(
+      path.join(worktreeDir, '.git'),
+      `gitdir: ${path.join(mainRepoDir, '.git', 'worktrees', 'my-worktree')}\n`
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves identity for main repo', async () => {
+    const identity = await gitIdentityResolver.resolveIdentity(mainRepoDir);
+    expect(identity).toBeDefined();
+    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.name).toBe('main-repo');
+  });
+
+  it('resolves identity for worktree', async () => {
+    const identity = await gitIdentityResolver.resolveIdentity(worktreeDir);
+    expect(identity).toBeDefined();
+    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.name).toBe('main-repo');
+  });
+});

--- a/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { gitIdentityResolver } from '@main/services/parsing/GitIdentityResolver';
+
+describe('GitIdentityResolver - Upwards Search', () => {
+  let tmpDir: string;
+  let mainRepoDir: string;
+  let worktreeDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-upwards-test-'));
+    mainRepoDir = path.join(tmpDir, 'main-repo');
+    worktreeDir = path.join(tmpDir, 'my-worktree');
+
+    fs.mkdirSync(mainRepoDir);
+    fs.mkdirSync(path.join(mainRepoDir, '.git'));
+    fs.mkdirSync(path.join(mainRepoDir, '.git', 'worktrees'));
+    fs.mkdirSync(path.join(mainRepoDir, '.git', 'worktrees', 'my-worktree'));
+
+    fs.writeFileSync(
+      path.join(mainRepoDir, '.git', 'config'),
+      '[remote "origin"]\n\turl = git@github.com:matt1398/claude-devtools.git\n'
+    );
+
+    fs.mkdirSync(worktreeDir);
+    fs.writeFileSync(
+      path.join(worktreeDir, '.git'),
+      `gitdir: ../main-repo/.git/worktrees/my-worktree\n`
+    );
+
+    // Create subdirectories
+    fs.mkdirSync(path.join(mainRepoDir, 'src'));
+    fs.mkdirSync(path.join(worktreeDir, 'src'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves identity when path is a subdirectory of main repo', async () => {
+    const identity = await gitIdentityResolver.resolveIdentity(path.join(mainRepoDir, 'src'));
+    expect(identity).toBeDefined();
+    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(await gitIdentityResolver.isWorktree(path.join(mainRepoDir, 'src'))).toBe(false);
+  });
+
+  it('resolves identity when path is a subdirectory of a worktree (with relative gitdir)', async () => {
+    const identity = await gitIdentityResolver.resolveIdentity(path.join(worktreeDir, 'src'));
+    expect(identity).toBeDefined();
+    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(await gitIdentityResolver.isWorktree(path.join(worktreeDir, 'src'))).toBe(true);
+  });
+});

--- a/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
@@ -9,8 +9,8 @@ describe('GitIdentityResolver - Upwards Search', () => {
   let mainRepoDir: string;
   let worktreeDir: string;
 
-  beforeEach(() => {
-    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'git-upwards-test-')));
+  beforeEach(async () => {
+    tmpDir = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'git-upwards-test-')));
     mainRepoDir = path.join(tmpDir, 'main-repo');
     worktreeDir = path.join(tmpDir, 'my-worktree');
 
@@ -42,7 +42,7 @@ describe('GitIdentityResolver - Upwards Search', () => {
   it('resolves identity when path is a subdirectory of main repo', async () => {
     const identity = await gitIdentityResolver.resolveIdentity(path.join(mainRepoDir, 'src'));
     expect(identity).toBeDefined();
-    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.mainGitDir).toBe(await fs.promises.realpath(path.join(mainRepoDir, '.git')));
     expect(identity?.remoteUrl).toBe('git@github.com:matt1398/claude-devtools.git');
     expect(await gitIdentityResolver.isWorktree(path.join(mainRepoDir, 'src'))).toBe(false);
   });
@@ -50,7 +50,7 @@ describe('GitIdentityResolver - Upwards Search', () => {
   it('resolves identity when path is a subdirectory of a worktree (with relative gitdir)', async () => {
     const identity = await gitIdentityResolver.resolveIdentity(path.join(worktreeDir, 'src'));
     expect(identity).toBeDefined();
-    expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.mainGitDir).toBe(await fs.promises.realpath(path.join(mainRepoDir, '.git')));
     expect(identity?.remoteUrl).toBe('git@github.com:matt1398/claude-devtools.git');
     expect(await gitIdentityResolver.isWorktree(path.join(worktreeDir, 'src'))).toBe(true);
   });

--- a/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
@@ -10,7 +10,7 @@ describe('GitIdentityResolver - Upwards Search', () => {
   let worktreeDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-upwards-test-'));
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'git-upwards-test-')));
     mainRepoDir = path.join(tmpDir, 'main-repo');
     worktreeDir = path.join(tmpDir, 'my-worktree');
 

--- a/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
+++ b/test/main/services/parsing/GitIdentityResolver.upwards.test.ts
@@ -43,6 +43,7 @@ describe('GitIdentityResolver - Upwards Search', () => {
     const identity = await gitIdentityResolver.resolveIdentity(path.join(mainRepoDir, 'src'));
     expect(identity).toBeDefined();
     expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.remoteUrl).toBe('git@github.com:matt1398/claude-devtools.git');
     expect(await gitIdentityResolver.isWorktree(path.join(mainRepoDir, 'src'))).toBe(false);
   });
 
@@ -50,6 +51,7 @@ describe('GitIdentityResolver - Upwards Search', () => {
     const identity = await gitIdentityResolver.resolveIdentity(path.join(worktreeDir, 'src'));
     expect(identity).toBeDefined();
     expect(identity?.mainGitDir).toBe(fs.realpathSync(path.join(mainRepoDir, '.git')));
+    expect(identity?.remoteUrl).toBe('git@github.com:matt1398/claude-devtools.git');
     expect(await gitIdentityResolver.isWorktree(path.join(worktreeDir, 'src'))).toBe(true);
   });
 });


### PR DESCRIPTION
GitIdentityResolver previously only looked for a `.git` file/directory exactly at `projectPath` instead of searching upwards to the project root. This caused discovery to fail when Claude was run inside a subdirectory of a git worktree or normal repository. Without a resolved identity, `WorktreeGrouper` fell back to heuristic path parsing and incorrectly split the session into a phantom repository group named after the subdirectory, preventing it from appearing in the worktree/session dropdown under the main repository.

Fix:
- Modify `resolveIdentity`, `isWorktree`, `getBranch`, `detectWorktreeSource`, and `getGitWorktreeName` to search upwards for the `.git` file/directory.
- Add test coverage for `GitIdentityResolver` and `WorktreeGrouper` to ensure worktrees and subdirectories group correctly.

Fixes #188.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git worktree recognition and handling: upward search for the nearest repo marker, correct resolution of worktree pointers (including relative paths), reliable detection of main repo vs worktree, and consistent branch/main-repo resolution when invoked from subdirectories or worktree locations.

* **Tests**
  * Added end-to-end tests covering main repo vs worktree identities, upward-search scenarios, and repository grouping validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->