### PR TITLE
feat: extend hover copy button to tool results and intermediate AI text

### DIFF
--- a/src/renderer/components/chat/LastOutputDisplay.tsx
+++ b/src/renderer/components/chat/LastOutputDisplay.tsx
@@ -148,6 +148,9 @@ export const LastOutputDisplay = ({
               Error
             </span>
           )}
+          <div className="ml-auto">
+            <CopyButton text={lastOutput.toolResult} inline />
+          </div>
         </div>
 
         {/* Content */}

--- a/src/renderer/components/chat/items/TextItem.tsx
+++ b/src/renderer/components/chat/items/TextItem.tsx
@@ -50,7 +50,7 @@ export const TextItem: React.FC<TextItemProps> = React.memo(function TextItem({
       highlightStyle={highlightStyle}
       notificationDotColor={notificationDotColor}
     >
-      <MarkdownViewer content={fullContent} maxHeight="max-h-96" />
+      <MarkdownViewer content={fullContent} maxHeight="max-h-96" copyable />
     </BaseItem>
   );
 });


### PR DESCRIPTION
Two more surfaces benefit from the same hover CopyButton pattern that bff0910 added to `LastOutputDisplay`'s text variant:

- `LastOutputDisplay` tool_result block: inline CopyButton in the header
- `TextItem`: `copyable` on `MarkdownViewer`, matching `ThinkingItem`

## Validation
- `pnpm typecheck`, `pnpm test` (722/722), `pnpm lint:fix`, `pnpm build` — all pass
- Manually verified in dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown content is now copyable.

* **Style**
  * Copy button for tool results repositioned for improved accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matt1398/claude-devtools/pull/200)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->