### PR TITLE
feat: select & copy — cherry-pick parts of a session for export

### DIFF
--- a/src/renderer/components/chat/AIChatGroup.tsx
+++ b/src/renderer/components/chat/AIChatGroup.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { COLOR_TEXT_MUTED, COLOR_TEXT_SECONDARY } from '@renderer/constants/cssVariables';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import { useTabUI } from '@renderer/hooks/useTabUI';
 import { useStore } from '@renderer/store';
 import { enhanceAIGroup, type PrecedingSlashInfo } from '@renderer/utils/aiGroupEnhancer';
@@ -24,6 +25,7 @@ import type {
   EnhancedAIGroup,
   UserGroup,
 } from '@renderer/types/groups';
+import type { ToolFieldKey } from '@renderer/utils/conversationExtractor';
 import type { TriggerColor } from '@shared/constants/triggerColors';
 
 /**
@@ -120,6 +122,86 @@ function containsToolUseId(items: AIGroupDisplayItem[], toolUseId: string): bool
  * - DisplayItemList: Shows items when expanded with inline expansion support
  * - Manages local expansion state and inline item expansion
  */
+
+// Checkbox supporting indeterminate state for tool items.
+const TriStateCheckbox = ({
+  checked,
+  indeterminate,
+  onChange,
+  className,
+  title,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onChange: () => void;
+  className?: string;
+  title?: string;
+}): React.JSX.Element => {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      className={className}
+      title={title}
+    />
+  );
+};
+
+// Parent checkbox for the last-output block.
+// Tool results get a tristate checkbox (name/summary/input/output fields as children).
+// Non-tool results get a simple checkbox.
+const LastOutputCheckbox = ({
+  exportId,
+  isToolResult,
+  getToolFields,
+  setToolItemFieldsAll,
+  isSelected,
+  toggle,
+}: {
+  exportId: string;
+  isToolResult: boolean;
+  getToolFields: (id: string) => Set<ToolFieldKey>;
+  setToolItemFieldsAll: (id: string, enabled: boolean) => void;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string) => void;
+}): React.JSX.Element => {
+  if (isToolResult) {
+    const fields = getToolFields(exportId);
+    const numOn = fields.size;
+    const isPartial = numOn > 0 && numOn < 4;
+    return (
+      <TriStateCheckbox
+        checked={numOn > 0}
+        indeterminate={isPartial}
+        onChange={() => setToolItemFieldsAll(exportId, numOn === 0)}
+        className="mt-2 shrink-0 cursor-pointer accent-indigo-500"
+        title={
+          numOn === 0
+            ? 'Select tool result'
+            : isPartial
+              ? 'Partial — click to deselect'
+              : 'Deselect tool result'
+        }
+      />
+    );
+  }
+  return (
+    <input
+      type="checkbox"
+      checked={isSelected(exportId)}
+      onChange={() => toggle(exportId)}
+      className="mt-2 shrink-0 cursor-pointer accent-indigo-500"
+      title="Include in copy"
+    />
+  );
+};
+
 const AIChatGroupInner = ({
   aiGroup,
   highlightToolUseId,
@@ -134,6 +216,8 @@ const AIChatGroupInner = ({
     getExpandedDisplayItemIds,
     toggleDisplayItemExpansion,
     expandDisplayItem,
+    expandSubagentTrace,
+    expandAllSignal,
   } = useTabUI();
 
   // Per-tab session data, falling back to global state
@@ -379,6 +463,44 @@ const AIChatGroupInner = ({
     expandDisplayItem,
   ]);
 
+  // When "Expand All" is triggered, expand every display item in this group
+  const prevExpandAllSignalRef = useRef(0);
+  useEffect(() => {
+    if (expandAllSignal === 0 || expandAllSignal === prevExpandAllSignalRef.current) return;
+    prevExpandAllSignalRef.current = expandAllSignal;
+    enhanced.displayItems.forEach((item, i) => {
+      let itemId = '';
+      switch (item.type) {
+        case 'thinking':
+          itemId = `thinking-${i}`;
+          break;
+        case 'output':
+          itemId = `output-${i}`;
+          break;
+        case 'tool':
+          itemId = `tool-${item.tool.id}-${i}`;
+          break;
+        case 'subagent':
+          itemId = `subagent-${item.subagent.id}-${i}`;
+          expandSubagentTrace(item.subagent.id);
+          break;
+        case 'slash':
+          itemId = `slash-${item.slash.name}-${i}`;
+          break;
+        case 'teammate_message':
+          itemId = `teammate-${item.teammateMessage.id}-${i}`;
+          break;
+        case 'subagent_input':
+          itemId = `input-${i}`;
+          break;
+        case 'compact_boundary':
+          itemId = `compact-${i}`;
+          break;
+      }
+      if (itemId) expandDisplayItem(aiGroup.id, itemId);
+    });
+  }, [expandAllSignal, enhanced.displayItems, aiGroup.id, expandDisplayItem, expandSubagentTrace]);
+
   // Determine if there's content to toggle
   const hasToggleContent = enhanced.displayItems.length > 0;
 
@@ -386,6 +508,18 @@ const AIChatGroupInner = ({
   const handleItemClick = (itemId: string): void => {
     toggleDisplayItemExpansion(aiGroup.id, itemId);
   };
+
+  const {
+    isActive: isSelectionActive,
+    isSelected,
+    toggle,
+    getToolFields,
+    setToolItemFieldsAll,
+  } = useExportSelection();
+  const lastOutputExportId = `ai-last-${aiGroup.id}`;
+  const showLastOutputCheckbox =
+    isSelectionActive && enhanced.lastOutput !== null && enhanced.lastOutput.type !== 'ongoing';
+  const lastOutputIsToolResult = enhanced.lastOutput?.type === 'tool_result';
 
   return (
     <div className="space-y-3 border-l-2 pl-3" style={{ borderColor: 'var(--chat-ai-border)' }}>
@@ -514,13 +648,26 @@ const AIChatGroupInner = ({
       )}
 
       {/* Always-visible Output */}
-      <div>
-        <LastOutputDisplay
-          lastOutput={enhanced.lastOutput}
-          aiGroupId={aiGroup.id}
-          isLastGroup={aiGroup.isOngoing ?? false}
-          isSessionOngoing={isSessionOngoing}
-        />
+      <div className={showLastOutputCheckbox ? 'flex items-start gap-2' : ''}>
+        {showLastOutputCheckbox && (
+          <LastOutputCheckbox
+            exportId={lastOutputExportId}
+            isToolResult={lastOutputIsToolResult}
+            getToolFields={getToolFields}
+            setToolItemFieldsAll={setToolItemFieldsAll}
+            isSelected={isSelected}
+            toggle={toggle}
+          />
+        )}
+        <div className={showLastOutputCheckbox ? 'min-w-0 flex-1' : ''}>
+          <LastOutputDisplay
+            lastOutput={enhanced.lastOutput}
+            aiGroupId={aiGroup.id}
+            isLastGroup={aiGroup.isOngoing ?? false}
+            isSessionOngoing={isSessionOngoing}
+            exportId={showLastOutputCheckbox ? lastOutputExportId : undefined}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/chat/AIChatGroup.tsx
+++ b/src/renderer/components/chat/AIChatGroup.tsx
@@ -169,6 +169,7 @@ const LastOutputCheckbox = ({
       onChange={() => toggle(exportId)}
       className="mt-2 shrink-0 cursor-pointer accent-indigo-500"
       title="Include in copy"
+      aria-label="Include in copy"
     />
   );
 };

--- a/src/renderer/components/chat/AIChatGroup.tsx
+++ b/src/renderer/components/chat/AIChatGroup.tsx
@@ -187,7 +187,7 @@ const AIChatGroupInner = ({
     getExpandedDisplayItemIds,
     toggleDisplayItemExpansion,
     expandDisplayItem,
-    expandSubagentTrace,
+    expandMany,
     expandAllSignal,
   } = useTabUI();
 
@@ -434,43 +434,45 @@ const AIChatGroupInner = ({
     expandDisplayItem,
   ]);
 
-  // When "Expand All" is triggered, expand every display item in this group
+  // When "Expand All" is triggered, expand every display item + subagent trace
+  // in this group via a single batched store update.
   const prevExpandAllSignalRef = useRef(0);
   useEffect(() => {
     if (expandAllSignal === 0 || expandAllSignal === prevExpandAllSignalRef.current) return;
     prevExpandAllSignalRef.current = expandAllSignal;
+    const itemIds: string[] = [];
+    const subagentIds: string[] = [];
     enhanced.displayItems.forEach((item, i) => {
-      let itemId = '';
       switch (item.type) {
         case 'thinking':
-          itemId = `thinking-${i}`;
+          itemIds.push(`thinking-${i}`);
           break;
         case 'output':
-          itemId = `output-${i}`;
+          itemIds.push(`output-${i}`);
           break;
         case 'tool':
-          itemId = `tool-${item.tool.id}-${i}`;
+          itemIds.push(`tool-${item.tool.id}-${i}`);
           break;
         case 'subagent':
-          itemId = `subagent-${item.subagent.id}-${i}`;
-          expandSubagentTrace(item.subagent.id);
+          itemIds.push(`subagent-${item.subagent.id}-${i}`);
+          subagentIds.push(item.subagent.id);
           break;
         case 'slash':
-          itemId = `slash-${item.slash.name}-${i}`;
+          itemIds.push(`slash-${item.slash.name}-${i}`);
           break;
         case 'teammate_message':
-          itemId = `teammate-${item.teammateMessage.id}-${i}`;
+          itemIds.push(`teammate-${item.teammateMessage.id}-${i}`);
           break;
         case 'subagent_input':
-          itemId = `input-${i}`;
+          itemIds.push(`input-${i}`);
           break;
         case 'compact_boundary':
-          itemId = `compact-${i}`;
+          itemIds.push(`compact-${i}`);
           break;
       }
-      if (itemId) expandDisplayItem(aiGroup.id, itemId);
     });
-  }, [expandAllSignal, enhanced.displayItems, aiGroup.id, expandDisplayItem, expandSubagentTrace]);
+    expandMany(aiGroup.id, itemIds, subagentIds);
+  }, [expandAllSignal, enhanced.displayItems, aiGroup.id, expandMany]);
 
   // Determine if there's content to toggle
   const hasToggleContent = enhanced.displayItems.length > 0;

--- a/src/renderer/components/chat/AIChatGroup.tsx
+++ b/src/renderer/components/chat/AIChatGroup.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { TriStateCheckbox } from '@renderer/components/common/TriStateCheckbox';
 import { COLOR_TEXT_MUTED, COLOR_TEXT_SECONDARY } from '@renderer/constants/cssVariables';
 import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import { useTabUI } from '@renderer/hooks/useTabUI';
@@ -122,36 +123,6 @@ function containsToolUseId(items: AIGroupDisplayItem[], toolUseId: string): bool
  * - DisplayItemList: Shows items when expanded with inline expansion support
  * - Manages local expansion state and inline item expansion
  */
-
-// Checkbox supporting indeterminate state for tool items.
-const TriStateCheckbox = ({
-  checked,
-  indeterminate,
-  onChange,
-  className,
-  title,
-}: {
-  checked: boolean;
-  indeterminate: boolean;
-  onChange: () => void;
-  className?: string;
-  title?: string;
-}): React.JSX.Element => {
-  const ref = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (ref.current) ref.current.indeterminate = indeterminate;
-  }, [indeterminate]);
-  return (
-    <input
-      ref={ref}
-      type="checkbox"
-      checked={checked}
-      onChange={onChange}
-      className={className}
-      title={title}
-    />
-  );
-};
 
 // Parent checkbox for the last-output block.
 // Tool results get a tristate checkbox (name/summary/input/output fields as children).

--- a/src/renderer/components/chat/ChatHistory.tsx
+++ b/src/renderer/components/chat/ChatHistory.tsx
@@ -1,12 +1,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { ExportSelectionContext } from '@renderer/contexts/ExportSelectionContext';
 import { isNearBottom, useAutoScrollBottom } from '@renderer/hooks/useAutoScrollBottom';
 import { useTabNavigationController } from '@renderer/hooks/useTabNavigationController';
 import { useTabUI } from '@renderer/hooks/useTabUI';
 import { useVisibleAIGroup } from '@renderer/hooks/useVisibleAIGroup';
 import { useStore } from '@renderer/store';
+import {
+  assembleToolContent,
+  type ExportItemType,
+  extractExportItems,
+  type ToolFieldKey,
+} from '@renderer/utils/conversationExtractor';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { ChevronsDown } from 'lucide-react';
+import { Check, ChevronsDown, Clipboard } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 
 import { SessionContextPanel } from './SessionContextPanel/index';
@@ -21,6 +28,9 @@ import { ChatHistoryItem } from './ChatHistoryItem';
 import { ChatHistoryLoadingState } from './ChatHistoryLoadingState';
 
 import type { ContextInjection } from '@renderer/types/contextInjection';
+import type { ExportItem } from '@renderer/utils/conversationExtractor';
+
+const ALL_TOOL_FIELDS = new Set<ToolFieldKey>(['name', 'summary', 'input', 'output']);
 
 /**
  * Waits for two requestAnimationFrame cycles, allowing the virtualizer to render.
@@ -47,6 +57,8 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
     savedScrollTop,
     saveScrollPosition,
     expandAIGroup,
+    expandAllAIGroups,
+    triggerExpandAll,
     expandSubagentTrace,
     selectedContextPhase,
     setSelectedContextPhase,
@@ -99,6 +111,219 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
     sessionPhaseInfo,
     sessionDetail,
   } = tabData;
+
+  // Export selection mode
+  const { exportSelectionMode, closeExportSelectionMode } = useStore(
+    useShallow((s) => ({
+      exportSelectionMode: s.exportSelectionMode,
+      closeExportSelectionMode: s.closeExportSelectionMode,
+    }))
+  );
+
+  // Pre-computed export items (recalculated when selection mode opens or conversation changes)
+  const [exportItems, setExportItems] = useState<ExportItem[]>([]);
+  // selectedExportIds: source of truth for non-tool items; for tool items it's kept in sync with toolItemFields
+  const [selectedExportIds, setSelectedExportIds] = useState<Set<string>>(new Set());
+  const [copyConfirmed, setCopyConfirmed] = useState(false);
+  // Global defaults for toolbar batch toggles
+  const [toolFieldsEnabled, setToolFieldsEnabled] = useState<Set<ToolFieldKey>>(
+    new Set<ToolFieldKey>(['name', 'summary', 'input', 'output'])
+  );
+  // Per-tool-item field sets. Invariant: selectedExportIds.has(id) <=> toolItemFields.get(id)?.size > 0
+  const [toolItemFields, setToolItemFields] = useState<Map<string, Set<ToolFieldKey>>>(new Map());
+
+  useEffect(() => {
+    if (exportSelectionMode && conversation) {
+      const items = extractExportItems(conversation);
+      setExportItems(items);
+      const selectedIds = new Set<string>();
+      const fieldMap = new Map<string, Set<ToolFieldKey>>();
+      for (const item of items) {
+        if (item.selected) selectedIds.add(item.id);
+        if (item.type === 'tool') {
+          fieldMap.set(item.id, new Set<ToolFieldKey>(['name', 'summary', 'input', 'output']));
+        }
+      }
+      setSelectedExportIds(selectedIds);
+      setToolItemFields(fieldMap);
+    } else if (!exportSelectionMode) {
+      setExportItems([]);
+      setSelectedExportIds(new Set());
+      setToolItemFields(new Map());
+    }
+  }, [exportSelectionMode, conversation]);
+
+  // Non-tool items: simple toggle
+  const toggleExportItem = useCallback((id: string) => {
+    setSelectedExportIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Tool items: toggle a single field; auto-syncs selectedExportIds
+  const toggleToolItemField = useCallback(
+    (id: string, field: ToolFieldKey) => {
+      const current = toolItemFields.get(id) ?? ALL_TOOL_FIELDS;
+      const updated = new Set(current);
+      if (updated.has(field)) updated.delete(field);
+      else updated.add(field);
+      const newItemFields = new Map(toolItemFields);
+      newItemFields.set(id, updated);
+      setToolItemFields(newItemFields);
+      // Sync selectedExportIds
+      setSelectedExportIds((prev) => {
+        const next = new Set(prev);
+        if (updated.size === 0) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+    },
+    [toolItemFields]
+  );
+
+  // Tool items: set all 4 fields on or off at once; auto-syncs selectedExportIds
+  const setToolItemFieldsAll = useCallback(
+    (id: string, enabled: boolean) => {
+      const newFields = enabled ? new Set(ALL_TOOL_FIELDS) : new Set<ToolFieldKey>();
+      const newItemFields = new Map(toolItemFields);
+      newItemFields.set(id, newFields);
+      setToolItemFields(newItemFields);
+      setSelectedExportIds((prev) => {
+        const next = new Set(prev);
+        if (enabled) next.add(id);
+        else next.delete(id);
+        return next;
+      });
+    },
+    [toolItemFields]
+  );
+
+  // Toolbar: batch-toggle one field across all tool items; also syncs selectedExportIds
+  const toggleToolField = useCallback(
+    (field: ToolFieldKey) => {
+      const willEnable = !toolFieldsEnabled.has(field);
+      const newGlobal = new Set(toolFieldsEnabled);
+      if (willEnable) newGlobal.add(field);
+      else newGlobal.delete(field);
+      setToolFieldsEnabled(newGlobal);
+
+      const newItemFields = new Map(toolItemFields);
+      const newSelectedIds = new Set(selectedExportIds);
+      for (const [id, fields] of toolItemFields) {
+        const updated = new Set(fields);
+        if (willEnable) updated.add(field);
+        else updated.delete(field);
+        newItemFields.set(id, updated);
+        if (updated.size === 0) newSelectedIds.delete(id);
+        else newSelectedIds.add(id);
+      }
+      setToolItemFields(newItemFields);
+      setSelectedExportIds(newSelectedIds);
+    },
+    [toolFieldsEnabled, toolItemFields, selectedExportIds]
+  );
+
+  // Category helpers — operate on selectedExportIds (non-tool items) or all fields (tool items)
+  const getCategoryItems = useCallback(
+    (type: ExportItemType) => exportItems.filter((i) => i.type === type),
+    [exportItems]
+  );
+
+  const isCategoryAllSelected = useCallback(
+    (type: ExportItemType) => {
+      const cat = exportItems.filter((i) => i.type === type);
+      if (cat.length === 0) return false;
+      if (type === 'tool') {
+        return cat.every((i) => (toolItemFields.get(i.id)?.size ?? 0) === 4);
+      }
+      return cat.every((i) => selectedExportIds.has(i.id));
+    },
+    [exportItems, selectedExportIds, toolItemFields]
+  );
+
+  const isCategoryAnySelected = useCallback(
+    (type: ExportItemType) => {
+      if (type === 'tool') {
+        return exportItems.some(
+          (i) => i.type === 'tool' && (toolItemFields.get(i.id)?.size ?? 0) > 0
+        );
+      }
+      return exportItems.some((i) => i.type === type && selectedExportIds.has(i.id));
+    },
+    [exportItems, selectedExportIds, toolItemFields]
+  );
+
+  const toggleCategory = useCallback(
+    (type: ExportItemType) => {
+      const cat = exportItems.filter((i) => i.type === type);
+      if (cat.length === 0) return;
+      if (type === 'tool') {
+        const allFull = cat.every((i) => (toolItemFields.get(i.id)?.size ?? 0) === 4);
+        const enable = !allFull;
+        const newItemFields = new Map(toolItemFields);
+        const newSelectedIds = new Set(selectedExportIds);
+        for (const item of cat) {
+          newItemFields.set(item.id, enable ? new Set(ALL_TOOL_FIELDS) : new Set<ToolFieldKey>());
+          if (enable) newSelectedIds.add(item.id);
+          else newSelectedIds.delete(item.id);
+        }
+        setToolItemFields(newItemFields);
+        setSelectedExportIds(newSelectedIds);
+      } else {
+        const allSelected = cat.every((i) => selectedExportIds.has(i.id));
+        setSelectedExportIds((prev) => {
+          const next = new Set(prev);
+          if (allSelected) cat.forEach((i) => next.delete(i.id));
+          else cat.forEach((i) => next.add(i.id));
+          return next;
+        });
+      }
+    },
+    [exportItems, selectedExportIds, toolItemFields]
+  );
+
+  const handleCopySelected = useCallback(async () => {
+    const text = exportItems
+      .filter((i) => selectedExportIds.has(i.id))
+      .map((i) => {
+        if (i.type === 'tool' && i.toolFields) {
+          const fields = toolItemFields.get(i.id) ?? toolFieldsEnabled;
+          return assembleToolContent(i.toolFields, fields);
+        }
+        return i.content;
+      })
+      .filter(Boolean)
+      .join('\n\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyConfirmed(true);
+      setTimeout(() => setCopyConfirmed(false), 2000);
+    } catch {
+      // clipboard unavailable
+    }
+  }, [exportItems, selectedExportIds, toolItemFields, toolFieldsEnabled]);
+
+  const exportCtxValue = useMemo(
+    () => ({
+      isActive: exportSelectionMode,
+      isSelected: (id: string) => selectedExportIds.has(id),
+      toggle: toggleExportItem,
+      getToolFields: (id: string) => toolItemFields.get(id) ?? ALL_TOOL_FIELDS,
+      toggleToolItemField,
+      setToolItemFieldsAll,
+    }),
+    [
+      exportSelectionMode,
+      selectedExportIds,
+      toggleExportItem,
+      toolItemFields,
+      toggleToolItemField,
+      setToolItemFieldsAll,
+    ]
+  );
 
   // State for Context button hover (local state OK - doesn't need per-tab isolation)
   const [isContextButtonHovered, setIsContextButtonHovered] = useState(false);
@@ -745,148 +970,303 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
   if (!conversation || conversation.items.length === 0) return <ChatHistoryEmptyState />;
 
   return (
-    <div
-      className="flex flex-1 flex-col overflow-hidden"
-      style={{ backgroundColor: 'var(--color-surface)' }}
-    >
-      <div className="relative flex flex-1 overflow-hidden">
-        {/* Chat content */}
-        <div
-          ref={scrollContainerRef}
-          className="flex-1 overflow-y-auto"
-          style={{ backgroundColor: 'var(--color-surface)' }}
-          onScroll={checkScrollButton}
-        >
-          {/* Sticky Context button */}
-          {allContextInjections.length > 0 && (
-            <div className="pointer-events-none sticky top-0 z-10 flex justify-end px-4 pb-0 pt-3">
+    <ExportSelectionContext.Provider value={exportCtxValue}>
+      <div
+        className="flex flex-1 flex-col overflow-hidden"
+        style={{ backgroundColor: 'var(--color-surface)' }}
+      >
+        {/* Export selection toolbar — shown when selection mode is active */}
+        {exportSelectionMode && (
+          <div
+            className="flex shrink-0 flex-col gap-1 px-4 py-2"
+            style={{
+              backgroundColor: 'var(--color-surface-raised)',
+              borderBottom: '1px solid var(--color-border-emphasis)',
+            }}
+          >
+            {/* Row 1: category toggles + All/None shortcuts + count + Copy + Done */}
+            <div className="flex items-center gap-1.5">
+              {(
+                [
+                  ['user', 'User'],
+                  ['ai-text', 'Claude'],
+                  ['thinking', 'Thinking'],
+                  ['tool', 'Tool Calls'],
+                ] as [ExportItemType, string][]
+              )
+                .filter(([type]) => getCategoryItems(type).length > 0)
+                .map(([type, label]) => {
+                  const anyOn = isCategoryAnySelected(type);
+                  const allOn = isCategoryAllSelected(type);
+                  return (
+                    <button
+                      key={type}
+                      onClick={() => toggleCategory(type)}
+                      className="rounded border px-2 py-0.5 text-xs transition-colors"
+                      style={{
+                        borderColor: anyOn ? 'var(--color-border-emphasis)' : 'transparent',
+                        color: anyOn
+                          ? allOn
+                            ? 'var(--color-text)'
+                            : 'var(--color-text-secondary)'
+                          : 'var(--color-text-muted)',
+                        backgroundColor: anyOn ? 'var(--color-surface)' : 'transparent',
+                      }}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              <span
+                className="mx-0.5 select-none text-xs"
+                style={{ color: 'var(--color-border-emphasis)' }}
+              >
+                |
+              </span>
               <button
-                onClick={() => setContextPanelVisible(!isContextPanelVisible)}
-                onMouseEnter={() => setIsContextButtonHovered(true)}
-                onMouseLeave={() => setIsContextButtonHovered(false)}
-                className="pointer-events-auto flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs shadow-lg transition-colors"
+                onClick={() => setSelectedExportIds(new Set(exportItems.map((i) => i.id)))}
+                className="rounded px-1.5 py-0.5 text-xs transition-opacity hover:opacity-70"
+                style={{ color: 'var(--color-text-muted)' }}
+              >
+                All
+              </button>
+              <button
+                onClick={() => setSelectedExportIds(new Set())}
+                className="rounded px-1.5 py-0.5 text-xs transition-opacity hover:opacity-70"
+                style={{ color: 'var(--color-text-muted)' }}
+              >
+                None
+              </button>
+              <span
+                className="mx-0.5 select-none text-xs"
+                style={{ color: 'var(--color-border-emphasis)' }}
+              >
+                |
+              </span>
+              <button
+                onClick={() => {
+                  expandAllAIGroups(
+                    conversation.items.filter((i) => i.type === 'ai').map((i) => i.group.id)
+                  );
+                  triggerExpandAll();
+                }}
+                className="rounded px-1.5 py-0.5 text-xs transition-opacity hover:opacity-70"
+                style={{ color: 'var(--color-text-muted)' }}
+              >
+                Expand All
+              </button>
+              <div className="flex-1" />
+              <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                {selectedExportIds.size}/{exportItems.length}
+              </span>
+              <button
+                onClick={() => void handleCopySelected()}
+                disabled={selectedExportIds.size === 0}
+                className="flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
                 style={{
-                  backgroundColor: isContextPanelVisible
-                    ? 'var(--context-btn-active-bg)'
-                    : isContextButtonHovered
-                      ? 'var(--context-btn-bg-hover)'
-                      : 'var(--context-btn-bg)',
-                  color: isContextPanelVisible
-                    ? 'var(--context-btn-active-text)'
-                    : 'var(--color-text-secondary)',
+                  backgroundColor: copyConfirmed
+                    ? 'var(--badge-success-bg)'
+                    : 'var(--color-surface)',
+                  color: copyConfirmed ? '#fff' : 'var(--color-text)',
+                  border: '1px solid var(--color-border-emphasis)',
                 }}
               >
-                Context ({allContextInjections.length})
+                {copyConfirmed ? (
+                  <>
+                    <Check className="size-3" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <Clipboard className="size-3" />
+                    Copy {selectedExportIds.size}
+                  </>
+                )}
+              </button>
+              <button
+                onClick={closeExportSelectionMode}
+                className="rounded px-2 py-0.5 text-xs transition-opacity hover:opacity-70"
+                style={{ color: 'var(--color-text-muted)' }}
+              >
+                Done
               </button>
             </div>
-          )}
+
+            {/* Row 2: tool field toggles — only shown when tool items exist */}
+            {exportItems.some((i) => i.type === 'tool') && (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                  Tool fields:
+                </span>
+                {(
+                  [
+                    ['name', 'Name'],
+                    ['summary', 'Intent'],
+                    ['input', 'Input'],
+                    ['output', 'Output'],
+                  ] as [ToolFieldKey, string][]
+                ).map(([field, label]) => {
+                  const on = toolFieldsEnabled.has(field);
+                  return (
+                    <button
+                      key={field}
+                      onClick={() => toggleToolField(field)}
+                      className="rounded border px-2 py-0.5 text-xs transition-colors"
+                      style={{
+                        borderColor: on ? 'var(--color-border-emphasis)' : 'transparent',
+                        color: on ? 'var(--color-text-secondary)' : 'var(--color-text-muted)',
+                        backgroundColor: on ? 'var(--color-surface)' : 'transparent',
+                        opacity: on ? 1 : 0.5,
+                      }}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="relative flex flex-1 overflow-hidden">
+          {/* Chat content */}
           <div
-            className="mx-auto max-w-5xl px-6 py-8"
-            style={{ marginTop: allContextInjections.length > 0 ? '-2rem' : 0 }}
+            ref={scrollContainerRef}
+            className="flex-1 overflow-y-auto"
+            style={{ backgroundColor: 'var(--color-surface)' }}
+            onScroll={checkScrollButton}
           >
-            <div className="space-y-8">
-              {shouldVirtualize ? (
-                <div
+            {/* Sticky Context button */}
+            {allContextInjections.length > 0 && (
+              <div className="pointer-events-none sticky top-0 z-10 flex justify-end px-4 pb-0 pt-3">
+                <button
+                  onClick={() => setContextPanelVisible(!isContextPanelVisible)}
+                  onMouseEnter={() => setIsContextButtonHovered(true)}
+                  onMouseLeave={() => setIsContextButtonHovered(false)}
+                  className="pointer-events-auto flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs shadow-lg transition-colors"
                   style={{
-                    height: `${rowVirtualizer.getTotalSize()}px`,
-                    width: '100%',
-                    position: 'relative',
+                    backgroundColor: isContextPanelVisible
+                      ? 'var(--context-btn-active-bg)'
+                      : isContextButtonHovered
+                        ? 'var(--context-btn-bg-hover)'
+                        : 'var(--context-btn-bg)',
+                    color: isContextPanelVisible
+                      ? 'var(--context-btn-active-text)'
+                      : 'var(--color-text-secondary)',
                   }}
                 >
-                  {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                    const item = conversation.items[virtualRow.index];
-                    if (!item) return null;
-                    return (
-                      <div
-                        key={virtualRow.key}
-                        ref={rowVirtualizer.measureElement}
-                        data-index={virtualRow.index}
-                        className="pb-8"
-                        style={{
-                          position: 'absolute',
-                          top: 0,
-                          left: 0,
-                          width: '100%',
-                          transform: `translateY(${virtualRow.start}px)`,
-                        }}
-                      >
-                        <ChatHistoryItem
-                          item={item}
-                          highlightedGroupId={highlightedGroupId}
-                          highlightToolUseId={effectiveHighlightToolUseId}
-                          isSearchHighlight={isSearchHighlight}
-                          isNavigationHighlight={isNavigationHighlight}
-                          highlightColor={effectiveHighlightColor}
-                          registerChatItemRef={registerChatItemRef}
-                          registerAIGroupRef={registerAIGroupRefCombined}
-                          registerToolRef={registerToolRef}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : (
-                conversation.items.map((item) => (
-                  <ChatHistoryItem
-                    key={item.group.id}
-                    item={item}
-                    highlightedGroupId={highlightedGroupId}
-                    highlightToolUseId={effectiveHighlightToolUseId}
-                    isSearchHighlight={isSearchHighlight}
-                    isNavigationHighlight={isNavigationHighlight}
-                    highlightColor={effectiveHighlightColor}
-                    registerChatItemRef={registerChatItemRef}
-                    registerAIGroupRef={registerAIGroupRefCombined}
-                    registerToolRef={registerToolRef}
-                  />
-                ))
-              )}
+                  Context ({allContextInjections.length})
+                </button>
+              </div>
+            )}
+            <div
+              className="mx-auto max-w-5xl px-6 py-8"
+              style={{ marginTop: allContextInjections.length > 0 ? '-2rem' : 0 }}
+            >
+              <div className="space-y-8">
+                {shouldVirtualize ? (
+                  <div
+                    style={{
+                      height: `${rowVirtualizer.getTotalSize()}px`,
+                      width: '100%',
+                      position: 'relative',
+                    }}
+                  >
+                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                      const item = conversation.items[virtualRow.index];
+                      if (!item) return null;
+                      return (
+                        <div
+                          key={virtualRow.key}
+                          ref={rowVirtualizer.measureElement}
+                          data-index={virtualRow.index}
+                          className="pb-8"
+                          style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            transform: `translateY(${virtualRow.start}px)`,
+                          }}
+                        >
+                          <ChatHistoryItem
+                            item={item}
+                            highlightedGroupId={highlightedGroupId}
+                            highlightToolUseId={effectiveHighlightToolUseId}
+                            isSearchHighlight={isSearchHighlight}
+                            isNavigationHighlight={isNavigationHighlight}
+                            highlightColor={effectiveHighlightColor}
+                            registerChatItemRef={registerChatItemRef}
+                            registerAIGroupRef={registerAIGroupRefCombined}
+                            registerToolRef={registerToolRef}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  conversation.items.map((item) => (
+                    <ChatHistoryItem
+                      key={item.group.id}
+                      item={item}
+                      highlightedGroupId={highlightedGroupId}
+                      highlightToolUseId={effectiveHighlightToolUseId}
+                      isSearchHighlight={isSearchHighlight}
+                      isNavigationHighlight={isNavigationHighlight}
+                      highlightColor={effectiveHighlightColor}
+                      registerChatItemRef={registerChatItemRef}
+                      registerAIGroupRef={registerAIGroupRefCombined}
+                      registerToolRef={registerToolRef}
+                    />
+                  ))
+                )}
+              </div>
             </div>
           </div>
+
+          {/* Scroll to bottom button */}
+          {showScrollButton && (
+            <button
+              onClick={() => {
+                scrollToBottom('smooth');
+                setShowScrollButton(false);
+              }}
+              className="absolute bottom-5 z-20 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs shadow-lg transition-[right] duration-200"
+              style={{
+                right:
+                  isContextPanelVisible && allContextInjections.length > 0
+                    ? `calc(${CONTEXT_PANEL_WIDTH_PX}px + 1rem)`
+                    : '1rem',
+                backgroundColor: 'var(--context-btn-bg)',
+                color: 'var(--color-text-secondary)',
+                border: '1px solid var(--color-border-emphasis)',
+              }}
+              title="Scroll to bottom"
+            >
+              <ChevronsDown className="size-3.5" />
+              <span>Bottom</span>
+            </button>
+          )}
+
+          {/* Context panel sidebar */}
+          {isContextPanelVisible && allContextInjections.length > 0 && (
+            <div className="w-80 shrink-0">
+              <SessionContextPanel
+                injections={allContextInjections}
+                onClose={() => setContextPanelVisible(false)}
+                projectRoot={sessionDetail?.session?.projectPath}
+                onNavigateToTurn={handleNavigateToTurn}
+                onNavigateToTool={handleNavigateToTool}
+                onNavigateToUserGroup={handleNavigateToUserGroup}
+                totalSessionTokens={lastAiGroupTotalTokens}
+                phaseInfo={sessionPhaseInfo ?? undefined}
+                selectedPhase={selectedContextPhase}
+                onPhaseChange={setSelectedContextPhase}
+              />
+            </div>
+          )}
         </div>
-
-        {/* Scroll to bottom button */}
-        {showScrollButton && (
-          <button
-            onClick={() => {
-              scrollToBottom('smooth');
-              setShowScrollButton(false);
-            }}
-            className="absolute bottom-5 z-20 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs shadow-lg transition-[right] duration-200"
-            style={{
-              right:
-                isContextPanelVisible && allContextInjections.length > 0
-                  ? `calc(${CONTEXT_PANEL_WIDTH_PX}px + 1rem)`
-                  : '1rem',
-              backgroundColor: 'var(--context-btn-bg)',
-              color: 'var(--color-text-secondary)',
-              border: '1px solid var(--color-border-emphasis)',
-            }}
-            title="Scroll to bottom"
-          >
-            <ChevronsDown className="size-3.5" />
-            <span>Bottom</span>
-          </button>
-        )}
-
-        {/* Context panel sidebar */}
-        {isContextPanelVisible && allContextInjections.length > 0 && (
-          <div className="w-80 shrink-0">
-            <SessionContextPanel
-              injections={allContextInjections}
-              onClose={() => setContextPanelVisible(false)}
-              projectRoot={sessionDetail?.session?.projectPath}
-              onNavigateToTurn={handleNavigateToTurn}
-              onNavigateToTool={handleNavigateToTool}
-              onNavigateToUserGroup={handleNavigateToUserGroup}
-              totalSessionTokens={lastAiGroupTotalTokens}
-              phaseInfo={sessionPhaseInfo ?? undefined}
-              selectedPhase={selectedContextPhase}
-              onPhaseChange={setSelectedContextPhase}
-            />
-          </div>
-        )}
       </div>
-    </div>
+    </ExportSelectionContext.Provider>
   );
 };

--- a/src/renderer/components/chat/ChatHistory.tsx
+++ b/src/renderer/components/chat/ChatHistory.tsx
@@ -285,6 +285,26 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
     [exportItems, selectedExportIds, toolItemFields]
   );
 
+  // Select-all / deselect-all also mirror state into toolItemFields so the
+  // invariant (item selected ⟺ at least one field enabled) holds for tool items.
+  const selectAll = useCallback(() => {
+    const newItemFields = new Map(toolItemFields);
+    for (const item of exportItems) {
+      if (item.type === 'tool') newItemFields.set(item.id, new Set(ALL_TOOL_FIELDS));
+    }
+    setToolItemFields(newItemFields);
+    setSelectedExportIds(new Set(exportItems.map((i) => i.id)));
+  }, [exportItems, toolItemFields]);
+
+  const deselectAll = useCallback(() => {
+    const newItemFields = new Map(toolItemFields);
+    for (const item of exportItems) {
+      if (item.type === 'tool') newItemFields.set(item.id, new Set<ToolFieldKey>());
+    }
+    setToolItemFields(newItemFields);
+    setSelectedExportIds(new Set());
+  }, [exportItems, toolItemFields]);
+
   const handleCopySelected = useCallback(async () => {
     const text = exportItems
       .filter((i) => selectedExportIds.has(i.id))
@@ -1024,14 +1044,14 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
                 |
               </span>
               <button
-                onClick={() => setSelectedExportIds(new Set(exportItems.map((i) => i.id)))}
+                onClick={selectAll}
                 className="rounded px-1.5 py-0.5 text-xs transition-opacity hover:opacity-70"
                 style={{ color: 'var(--color-text-muted)' }}
               >
                 All
               </button>
               <button
-                onClick={() => setSelectedExportIds(new Set())}
+                onClick={deselectAll}
                 className="rounded px-1.5 py-0.5 text-xs transition-opacity hover:opacity-70"
                 style={{ color: 'var(--color-text-muted)' }}
               >

--- a/src/renderer/components/chat/ChatHistory.tsx
+++ b/src/renderer/components/chat/ChatHistory.tsx
@@ -305,6 +305,15 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
     setSelectedExportIds(new Set());
   }, [exportItems, toolItemFields]);
 
+  // Hold the copy-confirmation timer in a ref so it can be cleared on unmount
+  // (and on subsequent clicks while the previous confirmation is still showing).
+  const copyConfirmedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (copyConfirmedTimerRef.current) clearTimeout(copyConfirmedTimerRef.current);
+    };
+  }, []);
+
   const handleCopySelected = useCallback(async () => {
     const text = exportItems
       .filter((i) => selectedExportIds.has(i.id))
@@ -320,7 +329,11 @@ export const ChatHistory = ({ tabId }: ChatHistoryProps): JSX.Element => {
     try {
       await navigator.clipboard.writeText(text);
       setCopyConfirmed(true);
-      setTimeout(() => setCopyConfirmed(false), 2000);
+      if (copyConfirmedTimerRef.current) clearTimeout(copyConfirmedTimerRef.current);
+      copyConfirmedTimerRef.current = setTimeout(() => {
+        setCopyConfirmed(false);
+        copyConfirmedTimerRef.current = null;
+      }, 2000);
     } catch {
       // clipboard unavailable
     }

--- a/src/renderer/components/chat/DisplayItemList.tsx
+++ b/src/renderer/components/chat/DisplayItemList.tsx
@@ -385,6 +385,7 @@ export const DisplayItemList = React.memo(function DisplayItemList({
                     onChange={() => toggle(exportId)}
                     className="mt-1.5 shrink-0 cursor-pointer accent-indigo-500"
                     title="Include in copy"
+                    aria-label="Include in copy"
                   />
                 );
               })()}

--- a/src/renderer/components/chat/DisplayItemList.tsx
+++ b/src/renderer/components/chat/DisplayItemList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   CODE_BG,
@@ -8,6 +8,7 @@ import {
   TOOL_CALL_BORDER,
   TOOL_CALL_TEXT,
 } from '@renderer/constants/cssVariables';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import { formatTokensCompact } from '@renderer/utils/formatters';
 import { format } from 'date-fns';
 import { ChevronRight, Layers, MailOpen } from 'lucide-react';
@@ -38,6 +39,36 @@ interface DisplayItemListProps {
   /** Optional callback to register tool element refs for scroll targeting */
   registerToolRef?: (toolId: string, el: HTMLDivElement | null) => void;
 }
+
+/** Checkbox that supports the indeterminate (partial) state. */
+const TriStateCheckbox = ({
+  checked,
+  indeterminate,
+  onChange,
+  className,
+  title,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onChange: () => void;
+  className?: string;
+  title?: string;
+}): React.JSX.Element => {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      className={className}
+      title={title}
+    />
+  );
+};
 
 /**
  * Truncates text to a maximum length and adds ellipsis if needed.
@@ -78,6 +109,14 @@ export const DisplayItemList = React.memo(function DisplayItemList({
     setReplyLinkToolId(toolId);
   }, []);
 
+  const {
+    isActive: isSelectionActive,
+    isSelected,
+    toggle,
+    getToolFields,
+    setToolItemFieldsAll,
+  } = useExportSelection();
+
   /** Check if an item is part of the currently highlighted reply link */
   const isItemInReplyLink = (item: AIGroupDisplayItem): boolean => {
     if (!replyLinkToolId) return false;
@@ -95,11 +134,19 @@ export const DisplayItemList = React.memo(function DisplayItemList({
     );
   }
 
+  // Track count of extractable items (thinking / output / tool) seen so far.
+  // Used to generate stable export IDs that match conversationExtractor.ts.
+  let extractableCount = 0;
+
   return (
     <div className="space-y-2">
       {items.map((item, index) => {
         let itemKey = '';
         let element: React.ReactNode = null;
+        const isExtractable =
+          item.type === 'thinking' || item.type === 'output' || item.type === 'tool';
+        const exportId = isExtractable ? `ai-${aiGroupId}-${extractableCount}` : '';
+        if (isExtractable) extractableCount++;
 
         switch (item.type) {
           case 'thinking': {
@@ -161,6 +208,7 @@ export const DisplayItemList = React.memo(function DisplayItemList({
                 registerRef={
                   registerToolRef ? (el) => registerToolRef(item.tool.id, el) : undefined
                 }
+                exportId={isSelectionActive ? exportId : undefined}
               />
             );
             break;
@@ -328,13 +376,50 @@ export const DisplayItemList = React.memo(function DisplayItemList({
         return (
           <div
             key={itemKey}
+            className={isSelectionActive && isExtractable ? 'flex items-start gap-2' : ''}
             style={
               replyLinkToolId !== null
                 ? { opacity: isDimmed ? 0.2 : 1, transition: 'opacity 150ms ease' }
                 : undefined
             }
           >
-            {element}
+            {isSelectionActive &&
+              isExtractable &&
+              (() => {
+                if (item.type === 'tool') {
+                  const fields = getToolFields(exportId);
+                  const numOn = fields.size;
+                  const isChecked = numOn === 4;
+                  const isPartial = numOn > 0 && numOn < 4;
+                  return (
+                    <TriStateCheckbox
+                      checked={isChecked || isPartial}
+                      indeterminate={isPartial}
+                      onChange={() => setToolItemFieldsAll(exportId, numOn === 0)}
+                      className="mt-1.5 shrink-0 cursor-pointer accent-indigo-500"
+                      title={
+                        isChecked
+                          ? 'Deselect tool'
+                          : isPartial
+                            ? 'Toggle tool (partial)'
+                            : 'Select tool'
+                      }
+                    />
+                  );
+                }
+                return (
+                  <input
+                    type="checkbox"
+                    checked={isSelected(exportId)}
+                    onChange={() => toggle(exportId)}
+                    className="mt-1.5 shrink-0 cursor-pointer accent-indigo-500"
+                    title="Include in copy"
+                  />
+                );
+              })()}
+            <div className={isSelectionActive && isExtractable ? 'min-w-0 flex-1' : ''}>
+              {element}
+            </div>
           </div>
         );
       })}

--- a/src/renderer/components/chat/DisplayItemList.tsx
+++ b/src/renderer/components/chat/DisplayItemList.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
+import { TriStateCheckbox } from '@renderer/components/common/TriStateCheckbox';
 import {
   CODE_BG,
   CODE_BORDER,
@@ -39,36 +40,6 @@ interface DisplayItemListProps {
   /** Optional callback to register tool element refs for scroll targeting */
   registerToolRef?: (toolId: string, el: HTMLDivElement | null) => void;
 }
-
-/** Checkbox that supports the indeterminate (partial) state. */
-const TriStateCheckbox = ({
-  checked,
-  indeterminate,
-  onChange,
-  className,
-  title,
-}: {
-  checked: boolean;
-  indeterminate: boolean;
-  onChange: () => void;
-  className?: string;
-  title?: string;
-}): React.JSX.Element => {
-  const ref = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (ref.current) ref.current.indeterminate = indeterminate;
-  }, [indeterminate]);
-  return (
-    <input
-      ref={ref}
-      type="checkbox"
-      checked={checked}
-      onChange={onChange}
-      className={className}
-      title={title}
-    />
-  );
-};
 
 /**
  * Truncates text to a maximum length and adds ellipsis if needed.

--- a/src/renderer/components/chat/LastOutputDisplay.tsx
+++ b/src/renderer/components/chat/LastOutputDisplay.tsx
@@ -142,6 +142,7 @@ export const LastOutputDisplay = ({
                   checked={getToolFields(exportId!).has('name')}
                   onChange={() => toggleToolItemField(exportId!, 'name')}
                   title="Include tool name in copy"
+                  aria-label="Include tool name in copy"
                   className="cursor-pointer accent-indigo-500"
                 />
               )}
@@ -179,6 +180,7 @@ export const LastOutputDisplay = ({
                 checked={getToolFields(exportId!).has('output')}
                 onChange={() => toggleToolItemField(exportId!, 'output')}
                 title="Include output in copy"
+                aria-label="Include output in copy"
                 className="cursor-pointer accent-indigo-500"
               />
             </div>

--- a/src/renderer/components/chat/LastOutputDisplay.tsx
+++ b/src/renderer/components/chat/LastOutputDisplay.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import { useStore } from '@renderer/store';
 import { AlertTriangle, CheckCircle, FileCheck, XCircle } from 'lucide-react';
 import remarkGfm from 'remark-gfm';
@@ -21,6 +22,8 @@ interface LastOutputDisplayProps {
   isLastGroup?: boolean;
   /** Whether the session is ongoing (from sessions array, same source as sidebar) */
   isSessionOngoing?: boolean;
+  /** Export ID — when provided, shows per-field checkboxes in selection mode */
+  exportId?: string;
 }
 
 /**
@@ -39,7 +42,10 @@ export const LastOutputDisplay = ({
   aiGroupId,
   isLastGroup = false,
   isSessionOngoing = false,
+  exportId,
 }: Readonly<LastOutputDisplayProps>): React.JSX.Element | null => {
+  const { isActive: isSelectionActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const showFieldCheckboxes = isSelectionActive && Boolean(exportId);
   // Only re-render if THIS AI group has search matches
   const { searchQuery, searchMatches, currentSearchIndex } = useStore(
     useShallow((s) => {
@@ -129,16 +135,27 @@ export const LastOutputDisplay = ({
             }}
           />
           {lastOutput.toolName && (
-            <code
-              className="rounded px-1.5 py-0.5 text-xs"
-              style={{
-                backgroundColor: 'var(--tag-bg)',
-                color: 'var(--tag-text)',
-                border: '1px solid var(--tag-border)',
-              }}
-            >
-              {lastOutput.toolName}
-            </code>
+            <>
+              {showFieldCheckboxes && (
+                <input
+                  type="checkbox"
+                  checked={getToolFields(exportId!).has('name')}
+                  onChange={() => toggleToolItemField(exportId!, 'name')}
+                  title="Include tool name in copy"
+                  className="cursor-pointer accent-indigo-500"
+                />
+              )}
+              <code
+                className="rounded px-1.5 py-0.5 text-xs"
+                style={{
+                  backgroundColor: 'var(--tag-bg)',
+                  color: 'var(--tag-text)',
+                  border: '1px solid var(--tag-border)',
+                }}
+              >
+                {lastOutput.toolName}
+              </code>
+            </>
           )}
           {isError && (
             <span
@@ -152,6 +169,20 @@ export const LastOutputDisplay = ({
 
         {/* Content */}
         <div className="px-4 py-3">
+          {showFieldCheckboxes && (
+            <div className="mb-2 flex items-center gap-1.5">
+              <span className="text-xs" style={{ color: 'var(--tool-item-muted)' }}>
+                Output
+              </span>
+              <input
+                type="checkbox"
+                checked={getToolFields(exportId!).has('output')}
+                onChange={() => toggleToolItemField(exportId!, 'output')}
+                title="Include output in copy"
+                className="cursor-pointer accent-indigo-500"
+              />
+            </div>
+          )}
           <pre
             className="max-h-96 overflow-y-auto whitespace-pre-wrap break-words font-mono text-sm"
             style={{ color: 'var(--color-text)' }}

--- a/src/renderer/components/chat/UserChatGroup.tsx
+++ b/src/renderer/components/chat/UserChatGroup.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 
 import { api } from '@renderer/api';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import { useTabUI } from '@renderer/hooks/useTabUI';
 import { useStore } from '@renderer/store';
 import { parseTaskNotifications } from '@shared/utils/contentSanitizer';
@@ -348,6 +349,9 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
   const hasImages = content.images.length > 0;
   // Use rawText to preserve /commands inline
   const textContent = content.rawText ?? content.text ?? '';
+
+  const { isActive: isSelectionActive, isSelected, toggle } = useExportSelection();
+  const exportId = `user-${userGroup.id}`;
   const isLongContent = textContent.length > 500;
 
   // Parse task notifications from the original message content (before sanitization)
@@ -439,7 +443,16 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
     isLongContent && !isExpanded ? textContent.slice(0, 500) + '...' : textContent;
 
   return (
-    <div className="flex justify-end">
+    <div className="flex items-start justify-end gap-2">
+      {isSelectionActive && textContent && (
+        <input
+          type="checkbox"
+          checked={isSelected(exportId)}
+          onChange={() => toggle(exportId)}
+          className="mt-8 shrink-0 cursor-pointer accent-indigo-500"
+          title="Include in copy"
+        />
+      )}
       <div className="max-w-[85%] space-y-2">
         {/* Header - right aligned with improved hierarchy */}
         <div className="flex items-center justify-end gap-1.5">
@@ -509,10 +522,7 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
                   border: '1px solid var(--card-border)',
                 }}
               >
-                <StatusIcon
-                  className="mt-0.5 size-3.5 shrink-0"
-                  style={{ color: statusColor }}
-                />
+                <StatusIcon className="mt-0.5 size-3.5 shrink-0" style={{ color: statusColor }} />
                 <div className="min-w-0 flex-1 space-y-0.5">
                   <div
                     className="text-xs font-medium leading-snug"
@@ -520,7 +530,10 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
                   >
                     {cmdName}
                   </div>
-                  <div className="flex items-center gap-2 text-[10px]" style={{ color: 'var(--color-text-muted)' }}>
+                  <div
+                    className="flex items-center gap-2 text-[10px]"
+                    style={{ color: 'var(--color-text-muted)' }}
+                  >
                     <span className="capitalize">{notif.status}</span>
                     {exitCode != null && <span>exit {exitCode}</span>}
                     {notif.outputFile && (

--- a/src/renderer/components/chat/UserChatGroup.tsx
+++ b/src/renderer/components/chat/UserChatGroup.tsx
@@ -451,6 +451,7 @@ const UserChatGroupInner = ({ userGroup }: Readonly<UserChatGroupProps>): React.
           onChange={() => toggle(exportId)}
           className="mt-8 shrink-0 cursor-pointer accent-indigo-500"
           title="Include in copy"
+          aria-label="Include in copy"
         />
       )}
       <div className="max-w-[85%] space-y-2">

--- a/src/renderer/components/chat/items/BaseItem.tsx
+++ b/src/renderer/components/chat/items/BaseItem.tsx
@@ -6,11 +6,18 @@ import { ChevronRight } from 'lucide-react';
 
 import { formatDuration, formatTokens, getStatusDotColor } from './baseItemHelpers';
 
+import type { ToolFieldKey } from '@renderer/utils/conversationExtractor';
+
 // =============================================================================
 // Types
 // =============================================================================
 
 export type ItemStatus = 'ok' | 'error' | 'pending' | 'orphaned';
+
+export interface BaseItemExportSelection {
+  getField: (f: ToolFieldKey) => boolean;
+  toggleField: (f: ToolFieldKey) => void;
+}
 
 interface BaseItemProps {
   /** Icon component to display */
@@ -41,6 +48,8 @@ interface BaseItemProps {
   notificationDotColor?: TriggerColor;
   /** Children rendered when expanded */
   children?: React.ReactNode;
+  /** When set, renders inline field checkboxes for export selection mode */
+  exportSelection?: BaseItemExportSelection;
 }
 
 // =============================================================================
@@ -58,6 +67,27 @@ export const StatusDot: React.FC<{ status: ItemStatus }> = ({ status }) => {
     />
   );
 };
+
+// Checkbox that stops click propagation so it doesn't expand/collapse the item.
+const FieldCheckbox: React.FC<{ checked: boolean; onChange: () => void; title: string }> = ({
+  checked,
+  onChange,
+  title,
+}) => (
+  <span
+    className="shrink-0"
+    onClick={(e) => e.stopPropagation()}
+    onKeyDown={(e) => e.stopPropagation()}
+  >
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      title={title}
+      className="cursor-pointer accent-indigo-500"
+    />
+  </span>
+);
 
 // =============================================================================
 // Main Component
@@ -87,6 +117,7 @@ export const BaseItem: React.FC<BaseItemProps> = ({
   highlightStyle,
   notificationDotColor,
   children,
+  exportSelection,
 }) => {
   return (
     <div
@@ -118,6 +149,15 @@ export const BaseItem: React.FC<BaseItemProps> = ({
           {icon}
         </span>
 
+        {/* Name field checkbox — before the label */}
+        {exportSelection && (
+          <FieldCheckbox
+            checked={exportSelection.getField('name')}
+            onChange={() => exportSelection.toggleField('name')}
+            title="Include tool name in copy"
+          />
+        )}
+
         {/* Label */}
         <span className="text-sm font-medium" style={{ color: 'var(--tool-item-name)' }}>
           {label}
@@ -129,6 +169,14 @@ export const BaseItem: React.FC<BaseItemProps> = ({
             <span className="text-sm" style={{ color: TOOL_ITEM_MUTED }}>
               -
             </span>
+            {/* Intent/summary field checkbox — before the summary text */}
+            {exportSelection && (
+              <FieldCheckbox
+                checked={exportSelection.getField('summary')}
+                onChange={() => exportSelection.toggleField('summary')}
+                title="Include intent in copy"
+              />
+            )}
             <span className="flex-1 truncate text-sm" style={{ color: 'var(--tool-item-summary)' }}>
               {summary}
             </span>

--- a/src/renderer/components/chat/items/BaseItem.tsx
+++ b/src/renderer/components/chat/items/BaseItem.tsx
@@ -84,6 +84,7 @@ const FieldCheckbox: React.FC<{ checked: boolean; onChange: () => void; title: s
       checked={checked}
       onChange={onChange}
       title={title}
+      aria-label={title}
       className="cursor-pointer accent-indigo-500"
     />
   </span>

--- a/src/renderer/components/chat/items/LinkedToolItem.tsx
+++ b/src/renderer/components/chat/items/LinkedToolItem.tsx
@@ -10,6 +10,7 @@ import React, { useRef } from 'react';
 
 import { CARD_ICON_MUTED } from '@renderer/constants/cssVariables';
 import { getTeamColorSet } from '@renderer/constants/teamColors';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import {
   getToolContextTokens,
   getToolStatus,
@@ -40,6 +41,7 @@ import {
 } from './linkedTool';
 
 import type { LinkedToolItem as LinkedToolItemType } from '@renderer/types/groups';
+import type { ToolFieldKey } from '@renderer/utils/conversationExtractor';
 
 interface LinkedToolItemProps {
   linkedTool: LinkedToolItemType;
@@ -53,6 +55,8 @@ interface LinkedToolItemProps {
   notificationDotColor?: TriggerColor;
   /** Optional ref registration callback for external scroll control */
   registerRef?: (el: HTMLDivElement | null) => void;
+  /** Export ID for this item — enables per-field checkboxes in selection mode */
+  exportId?: string;
 }
 
 export const LinkedToolItem: React.FC<LinkedToolItemProps> = React.memo(function LinkedToolItem({
@@ -63,10 +67,20 @@ export const LinkedToolItem: React.FC<LinkedToolItemProps> = React.memo(function
   highlightColor,
   notificationDotColor,
   registerRef,
+  exportId,
 }) {
   const status = getToolStatus(linkedTool);
   const summary = getToolSummary(linkedTool.name, linkedTool.input);
   const elementRef = useRef<HTMLDivElement>(null);
+
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const exportSelection =
+    isActive && exportId
+      ? {
+          getField: (f: ToolFieldKey) => getToolFields(exportId).has(f),
+          toggleField: (f: ToolFieldKey) => toggleToolItemField(exportId, f),
+        }
+      : undefined;
 
   // Combined ref callback - handles both internal ref and external registration
   const handleRef = (el: HTMLDivElement | null): void => {
@@ -164,21 +178,26 @@ export const LinkedToolItem: React.FC<LinkedToolItemProps> = React.memo(function
         highlightClasses={highlightClasses}
         highlightStyle={highlightStyle}
         notificationDotColor={notificationDotColor}
+        exportSelection={exportSelection}
       >
         {/* Read tool with CodeBlockViewer */}
-        {useReadViewer && <ReadToolViewer linkedTool={linkedTool} />}
+        {useReadViewer && <ReadToolViewer linkedTool={linkedTool} exportId={exportId} />}
 
         {/* Edit tool with DiffViewer */}
-        {useEditViewer && <EditToolViewer linkedTool={linkedTool} status={status} />}
+        {useEditViewer && (
+          <EditToolViewer linkedTool={linkedTool} status={status} exportId={exportId} />
+        )}
 
         {/* Write tool */}
-        {useWriteViewer && <WriteToolViewer linkedTool={linkedTool} />}
+        {useWriteViewer && <WriteToolViewer linkedTool={linkedTool} exportId={exportId} />}
 
         {/* Skill tool with instructions */}
-        {useSkillViewer && <SkillToolViewer linkedTool={linkedTool} />}
+        {useSkillViewer && <SkillToolViewer linkedTool={linkedTool} exportId={exportId} />}
 
         {/* Default rendering for other tools */}
-        {useDefaultViewer && <DefaultToolViewer linkedTool={linkedTool} status={status} />}
+        {useDefaultViewer && (
+          <DefaultToolViewer linkedTool={linkedTool} status={status} exportId={exportId} />
+        )}
 
         {/* Error output for Read tool */}
         {showReadError && <ToolErrorDisplay linkedTool={linkedTool} />}

--- a/src/renderer/components/chat/items/linkedTool/CollapsibleOutputSection.tsx
+++ b/src/renderer/components/chat/items/linkedTool/CollapsibleOutputSection.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 
 import { type ItemStatus, StatusDot } from '../BaseItem';
@@ -16,27 +17,51 @@ interface CollapsibleOutputSectionProps {
   children: React.ReactNode;
   /** Label shown in the header (default: "Output") */
   label?: string;
+  /** Export ID of the parent tool item — when set, shows an output field checkbox */
+  exportId?: string;
 }
 
 export const CollapsibleOutputSection: React.FC<CollapsibleOutputSectionProps> = ({
   status,
   children,
   label = 'Output',
+  exportId,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+
+  const showCheckbox = isActive && Boolean(exportId);
+  const outputChecked = exportId ? getToolFields(exportId).has('output') : true;
 
   return (
     <div>
-      <button
-        type="button"
-        className="mb-1 flex items-center gap-2 text-xs"
-        style={{ color: 'var(--tool-item-muted)', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
-        onClick={() => setIsExpanded((prev) => !prev)}
-      >
-        {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
-        {label}
-        <StatusDot status={status} />
-      </button>
+      <div className="mb-1 flex items-center gap-1.5">
+        <button
+          type="button"
+          className="flex items-center gap-1.5 text-xs"
+          style={{
+            color: 'var(--tool-item-muted)',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+          }}
+          onClick={() => setIsExpanded((prev) => !prev)}
+        >
+          {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+          {label}
+          <StatusDot status={status} />
+        </button>
+        {showCheckbox && (
+          <input
+            type="checkbox"
+            checked={outputChecked}
+            onChange={() => toggleToolItemField(exportId!, 'output')}
+            title="Include output in copy"
+            className="cursor-pointer accent-indigo-500"
+          />
+        )}
+      </div>
       {isExpanded && (
         <div
           className="max-h-96 overflow-auto rounded p-3 font-mono text-xs"
@@ -44,9 +69,7 @@ export const CollapsibleOutputSection: React.FC<CollapsibleOutputSectionProps> =
             backgroundColor: 'var(--code-bg)',
             border: '1px solid var(--code-border)',
             color:
-              status === 'error'
-                ? 'var(--tool-result-error-text)'
-                : 'var(--color-text-secondary)',
+              status === 'error' ? 'var(--tool-result-error-text)' : 'var(--color-text-secondary)',
           }}
         >
           {children}

--- a/src/renderer/components/chat/items/linkedTool/CollapsibleOutputSection.tsx
+++ b/src/renderer/components/chat/items/linkedTool/CollapsibleOutputSection.tsx
@@ -58,6 +58,7 @@ export const CollapsibleOutputSection: React.FC<CollapsibleOutputSectionProps> =
             checked={outputChecked}
             onChange={() => toggleToolItemField(exportId!, 'output')}
             title="Include output in copy"
+            aria-label="Include output in copy"
             className="cursor-pointer accent-indigo-500"
           />
         )}

--- a/src/renderer/components/chat/items/linkedTool/DefaultToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/DefaultToolViewer.tsx
@@ -44,6 +44,7 @@ export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = ({
               checked={inputChecked}
               onChange={() => toggleToolItemField(exportId!, 'input')}
               title="Include input in copy"
+              aria-label="Include input in copy"
               className="cursor-pointer accent-indigo-500"
             />
           )}

--- a/src/renderer/components/chat/items/linkedTool/DefaultToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/DefaultToolViewer.tsx
@@ -6,6 +6,8 @@
 
 import React from 'react';
 
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
+
 import { type ItemStatus } from '../BaseItem';
 
 import { CollapsibleOutputSection } from './CollapsibleOutputSection';
@@ -16,15 +18,35 @@ import type { LinkedToolItem } from '@renderer/types/groups';
 interface DefaultToolViewerProps {
   linkedTool: LinkedToolItem;
   status: ItemStatus;
+  exportId?: string;
 }
 
-export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = ({ linkedTool, status }) => {
+export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = ({
+  linkedTool,
+  status,
+  exportId,
+}) => {
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const showCheckbox = isActive && Boolean(exportId);
+  const inputChecked = exportId ? getToolFields(exportId).has('input') : true;
+
   return (
     <>
       {/* Input Section */}
       <div>
-        <div className="mb-1 text-xs" style={{ color: 'var(--tool-item-muted)' }}>
-          Input
+        <div className="mb-1 flex items-center gap-1.5">
+          <span className="text-xs" style={{ color: 'var(--tool-item-muted)' }}>
+            Input
+          </span>
+          {showCheckbox && (
+            <input
+              type="checkbox"
+              checked={inputChecked}
+              onChange={() => toggleToolItemField(exportId!, 'input')}
+              title="Include input in copy"
+              className="cursor-pointer accent-indigo-500"
+            />
+          )}
         </div>
         <div
           className="max-h-96 overflow-auto rounded p-3 font-mono text-xs"
@@ -40,7 +62,7 @@ export const DefaultToolViewer: React.FC<DefaultToolViewerProps> = ({ linkedTool
 
       {/* Output Section — Collapsed by default */}
       {!linkedTool.isOrphaned && linkedTool.result && (
-        <CollapsibleOutputSection status={status}>
+        <CollapsibleOutputSection status={status} exportId={exportId}>
           {renderOutput(linkedTool.result.content)}
         </CollapsibleOutputSection>
       )}

--- a/src/renderer/components/chat/items/linkedTool/EditToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/EditToolViewer.tsx
@@ -50,6 +50,7 @@ export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, stat
               checked={inputChecked}
               onChange={() => toggleToolItemField(exportId!, 'input')}
               title="Include diff in copy"
+              aria-label="Include diff in copy"
               className="cursor-pointer accent-indigo-500"
             />
           </div>
@@ -82,6 +83,7 @@ export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, stat
                 checked={outputChecked}
                 onChange={() => toggleToolItemField(exportId!, 'output')}
                 title="Include result in copy"
+                aria-label="Include result in copy"
                 className="cursor-pointer accent-indigo-500"
               />
             )}

--- a/src/renderer/components/chat/items/linkedTool/EditToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/EditToolViewer.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { DiffViewer } from '@renderer/components/chat/viewers';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 
 import { type ItemStatus, StatusDot } from '../BaseItem';
 import { formatTokens } from '../baseItemHelpers';
@@ -18,9 +19,15 @@ import type { LinkedToolItem } from '@renderer/types/groups';
 interface EditToolViewerProps {
   linkedTool: LinkedToolItem;
   status: ItemStatus;
+  exportId?: string;
 }
 
-export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, status }) => {
+export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, status, exportId }) => {
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const showCheckbox = isActive && Boolean(exportId);
+  const inputChecked = exportId ? getToolFields(exportId).has('input') : true;
+  const outputChecked = exportId ? getToolFields(exportId).has('output') : true;
+
   const toolUseResult = linkedTool.result?.toolUseResult as Record<string, unknown> | undefined;
 
   const filePath = (toolUseResult?.filePath as string) || (linkedTool.input.file_path as string);
@@ -31,14 +38,31 @@ export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, stat
 
   return (
     <div className="space-y-3">
-      <DiffViewer
-        fileName={filePath}
-        oldString={oldString}
-        newString={newString}
-        tokenCount={linkedTool.callTokens}
-      />
+      {/* Input: the diff */}
+      <div>
+        {showCheckbox && (
+          <div className="mb-1 flex items-center gap-1.5">
+            <span className="text-xs" style={{ color: 'var(--tool-item-muted)' }}>
+              Diff
+            </span>
+            <input
+              type="checkbox"
+              checked={inputChecked}
+              onChange={() => toggleToolItemField(exportId!, 'input')}
+              title="Include diff in copy"
+              className="cursor-pointer accent-indigo-500"
+            />
+          </div>
+        )}
+        <DiffViewer
+          fileName={filePath}
+          oldString={oldString}
+          newString={newString}
+          tokenCount={linkedTool.callTokens}
+        />
+      </div>
 
-      {/* Show result status if available */}
+      {/* Output: result status */}
       {!linkedTool.isOrphaned && linkedTool.result != null && (
         <div>
           <div
@@ -51,6 +75,15 @@ export const EditToolViewer: React.FC<EditToolViewerProps> = ({ linkedTool, stat
               <span style={{ color: 'var(--color-text-muted)' }}>
                 ~{formatTokens(linkedTool.result.tokenCount)} tokens
               </span>
+            )}
+            {showCheckbox && (
+              <input
+                type="checkbox"
+                checked={outputChecked}
+                onChange={() => toggleToolItemField(exportId!, 'output')}
+                title="Include result in copy"
+                className="cursor-pointer accent-indigo-500"
+              />
             )}
           </div>
           <div

--- a/src/renderer/components/chat/items/linkedTool/ReadToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/ReadToolViewer.tsx
@@ -7,25 +7,26 @@
 import React from 'react';
 
 import { CodeBlockViewer, MarkdownViewer } from '@renderer/components/chat/viewers';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 
 import type { LinkedToolItem } from '@renderer/types/groups';
 
 interface ReadToolViewerProps {
   linkedTool: LinkedToolItem;
+  exportId?: string;
 }
 
-export const ReadToolViewer: React.FC<ReadToolViewerProps> = ({ linkedTool }) => {
+export const ReadToolViewer: React.FC<ReadToolViewerProps> = ({ linkedTool, exportId }) => {
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const showCheckbox = isActive && Boolean(exportId);
+  const outputChecked = exportId ? getToolFields(exportId).has('output') : true;
+
   const filePath = linkedTool.input.file_path as string;
 
   // Prefer enriched toolUseResult data
   const toolUseResult = linkedTool.result?.toolUseResult as Record<string, unknown> | undefined;
   const fileData = toolUseResult?.file as
-    | {
-        content?: string;
-        startLine?: number;
-        totalLines?: number;
-        numLines?: number;
-      }
+    | { content?: string; startLine?: number; totalLines?: number; numLines?: number }
     | undefined;
 
   // Get content: prefer enriched file data, fall back to raw result content
@@ -55,10 +56,28 @@ export const ReadToolViewer: React.FC<ReadToolViewerProps> = ({ linkedTool }) =>
       : undefined;
 
   const isMarkdownFile = /\.mdx?$/i.test(filePath);
-  const [viewMode, setViewMode] = React.useState<'code' | 'preview'>(isMarkdownFile ? 'preview' : 'code');
+  const [viewMode, setViewMode] = React.useState<'code' | 'preview'>(
+    isMarkdownFile ? 'preview' : 'code'
+  );
 
   return (
     <div className="space-y-2">
+      {/* Output label + checkbox */}
+      {showCheckbox && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs" style={{ color: 'var(--tool-item-muted)' }}>
+            File content
+          </span>
+          <input
+            type="checkbox"
+            checked={outputChecked}
+            onChange={() => toggleToolItemField(exportId!, 'output')}
+            title="Include file content in copy"
+            className="cursor-pointer accent-indigo-500"
+          />
+        </div>
+      )}
+
       {isMarkdownFile && (
         <div className="flex items-center justify-end gap-1">
           <button

--- a/src/renderer/components/chat/items/linkedTool/ReadToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/ReadToolViewer.tsx
@@ -73,6 +73,7 @@ export const ReadToolViewer: React.FC<ReadToolViewerProps> = ({ linkedTool, expo
             checked={outputChecked}
             onChange={() => toggleToolItemField(exportId!, 'output')}
             title="Include file content in copy"
+            aria-label="Include file content in copy"
             className="cursor-pointer accent-indigo-500"
           />
         </div>

--- a/src/renderer/components/chat/items/linkedTool/SkillToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/SkillToolViewer.tsx
@@ -7,14 +7,20 @@
 import React from 'react';
 
 import { CodeBlockViewer } from '@renderer/components/chat/viewers';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 
 import type { LinkedToolItem } from '@renderer/types/groups';
 
 interface SkillToolViewerProps {
   linkedTool: LinkedToolItem;
+  exportId?: string;
 }
 
-export const SkillToolViewer: React.FC<SkillToolViewerProps> = ({ linkedTool }) => {
+export const SkillToolViewer: React.FC<SkillToolViewerProps> = ({ linkedTool, exportId }) => {
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const showCheckbox = isActive && Boolean(exportId);
+  const outputChecked = exportId ? getToolFields(exportId).has('output') : true;
+
   const skillInstructions = linkedTool.skillInstructions;
   const skillName = (linkedTool.input.skill as string) || 'Unknown Skill';
 
@@ -30,11 +36,22 @@ export const SkillToolViewer: React.FC<SkillToolViewerProps> = ({ linkedTool }) 
 
   return (
     <div className="space-y-3">
-      {/* Initial result */}
+      {/* Result */}
       {resultText && (
         <div>
-          <div className="mb-1 text-xs" style={{ color: 'var(--tool-item-muted)' }}>
-            Result
+          <div className="mb-1 flex items-center gap-1.5">
+            <span className="text-xs" style={{ color: 'var(--tool-item-muted)' }}>
+              Result
+            </span>
+            {showCheckbox && (
+              <input
+                type="checkbox"
+                checked={outputChecked}
+                onChange={() => toggleToolItemField(exportId!, 'output')}
+                title="Include result in copy"
+                className="cursor-pointer accent-indigo-500"
+              />
+            )}
           </div>
           <div
             className="overflow-x-auto rounded p-3 font-mono text-xs"

--- a/src/renderer/components/chat/items/linkedTool/SkillToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/SkillToolViewer.tsx
@@ -49,6 +49,7 @@ export const SkillToolViewer: React.FC<SkillToolViewerProps> = ({ linkedTool, ex
                 checked={outputChecked}
                 onChange={() => toggleToolItemField(exportId!, 'output')}
                 title="Include result in copy"
+                aria-label="Include result in copy"
                 className="cursor-pointer accent-indigo-500"
               />
             )}

--- a/src/renderer/components/chat/items/linkedTool/WriteToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/WriteToolViewer.tsx
@@ -7,26 +7,44 @@
 import React from 'react';
 
 import { CodeBlockViewer, MarkdownViewer } from '@renderer/components/chat/viewers';
+import { useExportSelection } from '@renderer/contexts/ExportSelectionContext';
 
 import type { LinkedToolItem } from '@renderer/types/groups';
 
 interface WriteToolViewerProps {
   linkedTool: LinkedToolItem;
+  exportId?: string;
 }
 
-export const WriteToolViewer: React.FC<WriteToolViewerProps> = ({ linkedTool }) => {
-  const toolUseResult = linkedTool.result?.toolUseResult as Record<string, unknown> | undefined;
+export const WriteToolViewer: React.FC<WriteToolViewerProps> = ({ linkedTool, exportId }) => {
+  const { isActive, getToolFields, toggleToolItemField } = useExportSelection();
+  const showCheckbox = isActive && Boolean(exportId);
+  const inputChecked = exportId ? getToolFields(exportId).has('input') : true;
 
+  const toolUseResult = linkedTool.result?.toolUseResult as Record<string, unknown> | undefined;
   const filePath = (toolUseResult?.filePath as string) || (linkedTool.input.file_path as string);
   const content = (toolUseResult?.content as string) || (linkedTool.input.content as string) || '';
   const isCreate = toolUseResult?.type === 'create';
   const isMarkdownFile = /\.mdx?$/i.test(filePath);
-  const [viewMode, setViewMode] = React.useState<'code' | 'preview'>(isMarkdownFile ? 'preview' : 'code');
+  const [viewMode, setViewMode] = React.useState<'code' | 'preview'>(
+    isMarkdownFile ? 'preview' : 'code'
+  );
 
   return (
     <div className="space-y-2">
-      <div className="mb-1 text-xs text-zinc-500">
-        {isCreate ? 'Created file' : 'Wrote to file'}
+      <div className="flex items-center gap-1.5">
+        <span className="mb-1 text-xs text-zinc-500">
+          {isCreate ? 'Created file' : 'Wrote to file'}
+        </span>
+        {showCheckbox && (
+          <input
+            type="checkbox"
+            checked={inputChecked}
+            onChange={() => toggleToolItemField(exportId!, 'input')}
+            title="Include file content in copy"
+            className="cursor-pointer accent-indigo-500"
+          />
+        )}
       </div>
       {isMarkdownFile && (
         <div className="flex items-center justify-end gap-1">

--- a/src/renderer/components/chat/items/linkedTool/WriteToolViewer.tsx
+++ b/src/renderer/components/chat/items/linkedTool/WriteToolViewer.tsx
@@ -42,6 +42,7 @@ export const WriteToolViewer: React.FC<WriteToolViewerProps> = ({ linkedTool, ex
             checked={inputChecked}
             onChange={() => toggleToolItemField(exportId!, 'input')}
             title="Include file content in copy"
+            aria-label="Include file content in copy"
             className="cursor-pointer accent-indigo-500"
           />
         )}

--- a/src/renderer/components/common/TriStateCheckbox.tsx
+++ b/src/renderer/components/common/TriStateCheckbox.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef } from 'react';
+
+/** Checkbox that supports the indeterminate (partial) state. */
+export const TriStateCheckbox = ({
+  checked,
+  indeterminate,
+  onChange,
+  className,
+  title,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onChange: () => void;
+  className?: string;
+  title?: string;
+}): React.JSX.Element => {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      className={className}
+      title={title}
+      aria-label={title}
+    />
+  );
+};

--- a/src/renderer/components/layout/MoreMenu.tsx
+++ b/src/renderer/components/layout/MoreMenu.tsx
@@ -11,7 +11,15 @@ import { api } from '@renderer/api';
 import { useStore } from '@renderer/store';
 import { triggerDownload } from '@renderer/utils/sessionExporter';
 import { formatShortcut } from '@renderer/utils/stringUtils';
-import { Braces, FileText, MoreHorizontal, Search, Settings, Type } from 'lucide-react';
+import {
+  Braces,
+  ClipboardList,
+  FileText,
+  MoreHorizontal,
+  Search,
+  Settings,
+  Type,
+} from 'lucide-react';
 
 import type { Tab } from '@renderer/types/tabs';
 import type { ExportFormat } from '@renderer/utils/sessionExporter';
@@ -42,6 +50,7 @@ export const MoreMenu = ({
 
   const openCommandPalette = useStore((s) => s.openCommandPalette);
   const openSettingsTab = useStore((s) => s.openSettingsTab);
+  const openExportSelectionMode = useStore((s) => s.openExportSelectionMode);
 
   // Close on outside click
   useEffect(() => {
@@ -112,6 +121,15 @@ export const MoreMenu = ({
 
   const sessionItems: MenuItem[] = isSessionWithData
     ? [
+        {
+          id: 'selective-copy',
+          label: 'Select & Copy…',
+          icon: ClipboardList,
+          onClick: () => {
+            openExportSelectionMode();
+            setIsOpen(false);
+          },
+        },
         {
           id: 'export-md',
           label: exportLoading ? 'Exporting…' : 'Export as Markdown',

--- a/src/renderer/contexts/ExportSelectionContext.tsx
+++ b/src/renderer/contexts/ExportSelectionContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext } from 'react';
+
+import type { ToolFieldKey } from '@renderer/utils/conversationExtractor';
+
+export interface ExportSelectionContextValue {
+  isActive: boolean;
+  /** True if item is selected (for non-tool items: in selectedExportIds; for tools: any field enabled) */
+  isSelected: (id: string) => boolean;
+  /** Toggle for non-tool items (user, ai-text, thinking, compact) */
+  toggle: (id: string) => void;
+  /** Returns the set of enabled fields for a tool item */
+  getToolFields: (id: string) => Set<ToolFieldKey>;
+  /** Toggle a single field for a tool item; auto-syncs item selection */
+  toggleToolItemField: (id: string, field: ToolFieldKey) => void;
+  /** Set all 4 fields on (enabled=true) or off (enabled=false); auto-syncs item selection */
+  setToolItemFieldsAll: (id: string, enabled: boolean) => void;
+}
+
+const ALL_FIELDS = new Set<ToolFieldKey>(['name', 'summary', 'input', 'output']);
+
+export const ExportSelectionContext = createContext<ExportSelectionContextValue>({
+  isActive: false,
+  isSelected: () => false,
+  toggle: () => {},
+  getToolFields: () => ALL_FIELDS,
+  toggleToolItemField: () => {},
+  setToolItemFieldsAll: () => {},
+});
+
+export const useExportSelection = (): ExportSelectionContextValue =>
+  useContext(ExportSelectionContext);

--- a/src/renderer/hooks/useTabUI.ts
+++ b/src/renderer/hooks/useTabUI.ts
@@ -35,6 +35,9 @@ interface UseTabUIReturn {
   isAIGroupExpanded: (aiGroupId: string) => boolean;
   toggleAIGroupExpansion: (aiGroupId: string) => void;
   expandAIGroup: (aiGroupId: string) => void;
+  expandAllAIGroups: (aiGroupIds: string[]) => void;
+  expandAllSignal: number;
+  triggerExpandAll: () => void;
   getExpandedDisplayItemIds: (aiGroupId: string) => Set<string>;
   toggleDisplayItemExpansion: (aiGroupId: string, itemId: string) => void;
   expandDisplayItem: (aiGroupId: string, itemId: string) => void;
@@ -77,6 +80,8 @@ export function useTabUI(): UseTabUIReturn {
   const {
     toggleAIGroupExpansionForTab,
     expandAIGroupForTab,
+    expandAllAIGroupsForTab,
+    triggerExpandAllForTab,
     toggleDisplayItemExpansionForTab,
     expandDisplayItemForTab,
     toggleSubagentTraceExpansionForTab,
@@ -89,6 +94,8 @@ export function useTabUI(): UseTabUIReturn {
     useShallow((s) => ({
       toggleAIGroupExpansionForTab: s.toggleAIGroupExpansionForTab,
       expandAIGroupForTab: s.expandAIGroupForTab,
+      expandAllAIGroupsForTab: s.expandAllAIGroupsForTab,
+      triggerExpandAllForTab: s.triggerExpandAllForTab,
       toggleDisplayItemExpansionForTab: s.toggleDisplayItemExpansionForTab,
       expandDisplayItemForTab: s.expandDisplayItemForTab,
       toggleSubagentTraceExpansionForTab: s.toggleSubagentTraceExpansionForTab,
@@ -127,6 +134,21 @@ export function useTabUI(): UseTabUIReturn {
     },
     [tabId, expandAIGroupForTab]
   );
+
+  const expandAllAIGroups = useCallback(
+    (aiGroupIds: string[]): void => {
+      if (!tabId) return;
+      expandAllAIGroupsForTab(tabId, aiGroupIds);
+    },
+    [tabId, expandAllAIGroupsForTab]
+  );
+
+  const expandAllSignal = tabState?.expandAllSignal ?? 0;
+
+  const triggerExpandAll = useCallback((): void => {
+    if (!tabId) return;
+    triggerExpandAllForTab(tabId);
+  }, [tabId, triggerExpandAllForTab]);
 
   // Display item expansion - derive from tabState
   const getExpandedDisplayItemIds = useCallback(
@@ -223,6 +245,9 @@ export function useTabUI(): UseTabUIReturn {
     isAIGroupExpanded,
     toggleAIGroupExpansion,
     expandAIGroup,
+    expandAllAIGroups,
+    expandAllSignal,
+    triggerExpandAll,
 
     // Display item expansion
     getExpandedDisplayItemIds,

--- a/src/renderer/hooks/useTabUI.ts
+++ b/src/renderer/hooks/useTabUI.ts
@@ -41,6 +41,7 @@ interface UseTabUIReturn {
   getExpandedDisplayItemIds: (aiGroupId: string) => Set<string>;
   toggleDisplayItemExpansion: (aiGroupId: string, itemId: string) => void;
   expandDisplayItem: (aiGroupId: string, itemId: string) => void;
+  expandMany: (aiGroupId: string, itemIds: string[], subagentIds: string[]) => void;
   isSubagentTraceExpanded: (subagentId: string) => boolean;
   toggleSubagentTraceExpansion: (subagentId: string) => void;
   expandSubagentTrace: (subagentId: string) => void;
@@ -84,6 +85,7 @@ export function useTabUI(): UseTabUIReturn {
     triggerExpandAllForTab,
     toggleDisplayItemExpansionForTab,
     expandDisplayItemForTab,
+    expandManyForTab,
     toggleSubagentTraceExpansionForTab,
     expandSubagentTraceForTab,
     setContextPanelVisibleForTab,
@@ -98,6 +100,7 @@ export function useTabUI(): UseTabUIReturn {
       triggerExpandAllForTab: s.triggerExpandAllForTab,
       toggleDisplayItemExpansionForTab: s.toggleDisplayItemExpansionForTab,
       expandDisplayItemForTab: s.expandDisplayItemForTab,
+      expandManyForTab: s.expandManyForTab,
       toggleSubagentTraceExpansionForTab: s.toggleSubagentTraceExpansionForTab,
       expandSubagentTraceForTab: s.expandSubagentTraceForTab,
       setContextPanelVisibleForTab: s.setContextPanelVisibleForTab,
@@ -172,6 +175,14 @@ export function useTabUI(): UseTabUIReturn {
       expandDisplayItemForTab(tabId, aiGroupId, itemId);
     },
     [tabId, expandDisplayItemForTab]
+  );
+
+  const expandMany = useCallback(
+    (aiGroupId: string, itemIds: string[], subagentIds: string[]): void => {
+      if (!tabId) return;
+      expandManyForTab(tabId, aiGroupId, itemIds, subagentIds);
+    },
+    [tabId, expandManyForTab]
   );
 
   // Subagent trace expansion - derive from tabState
@@ -253,6 +264,7 @@ export function useTabUI(): UseTabUIReturn {
     getExpandedDisplayItemIds,
     toggleDisplayItemExpansion,
     expandDisplayItem,
+    expandMany,
 
     // Subagent trace expansion
     isSubagentTraceExpanded,

--- a/src/renderer/store/slices/tabUISlice.ts
+++ b/src/renderer/store/slices/tabUISlice.ts
@@ -95,6 +95,13 @@ export interface TabUISlice {
   getExpandedDisplayItemIdsForTab: (tabId: string, aiGroupId: string) => Set<string>;
   /** Expand a display item for a specific tab (for auto-expand scenarios) */
   expandDisplayItemForTab: (tabId: string, aiGroupId: string, itemId: string) => void;
+  /** Expand many display items + subagent traces for a tab in a single store update */
+  expandManyForTab: (
+    tabId: string,
+    aiGroupId: string,
+    itemIds: string[],
+    subagentIds: string[]
+  ) => void;
 
   // Subagent trace expansion (per-tab)
   /** Toggle subagent trace expansion for a specific tab */
@@ -251,6 +258,34 @@ export const createTabUISlice: StateCreator<AppState, [], [], TabUISlice> = (set
     newDisplayItemMap.set(aiGroupId, newSet);
 
     newMap.set(tabId, { ...currentTabState, expandedDisplayItemIds: newDisplayItemMap });
+    set({ tabUIStates: newMap });
+  },
+
+  expandManyForTab: (
+    tabId: string,
+    aiGroupId: string,
+    itemIds: string[],
+    subagentIds: string[]
+  ) => {
+    if (itemIds.length === 0 && subagentIds.length === 0) return;
+    const state = get();
+    const newMap = new Map(state.tabUIStates);
+    const currentTabState = newMap.get(tabId) ?? createDefaultTabUIState();
+
+    const newDisplayItemMap = new Map(currentTabState.expandedDisplayItemIds);
+    const currentItems = newDisplayItemMap.get(aiGroupId) ?? new Set<string>();
+    const newItemSet = new Set(currentItems);
+    for (const id of itemIds) newItemSet.add(id);
+    newDisplayItemMap.set(aiGroupId, newItemSet);
+
+    const newSubagentSet = new Set(currentTabState.expandedSubagentTraceIds);
+    for (const id of subagentIds) newSubagentSet.add(id);
+
+    newMap.set(tabId, {
+      ...currentTabState,
+      expandedDisplayItemIds: newDisplayItemMap,
+      expandedSubagentTraceIds: newSubagentSet,
+    });
     set({ tabUIStates: newMap });
   },
 

--- a/src/renderer/store/slices/tabUISlice.ts
+++ b/src/renderer/store/slices/tabUISlice.ts
@@ -42,6 +42,9 @@ export interface TabUIState {
 
   /** Saved scroll position for restoring when switching back to this tab */
   savedScrollTop?: number;
+
+  /** Incremented each time "expand all" is triggered; AIChatGroup reacts to expand its items */
+  expandAllSignal: number;
 }
 
 /**
@@ -55,6 +58,7 @@ function createDefaultTabUIState(): TabUIState {
     showContextPanel: false,
     selectedContextPhase: null,
     savedScrollTop: undefined,
+    expandAllSignal: 0,
   };
 }
 
@@ -79,6 +83,10 @@ export interface TabUISlice {
   isAIGroupExpandedForTab: (tabId: string, aiGroupId: string) => boolean;
   /** Expand AI group for a specific tab (for auto-expand scenarios) */
   expandAIGroupForTab: (tabId: string, aiGroupId: string) => void;
+  /** Expand all AI groups for a tab at once */
+  expandAllAIGroupsForTab: (tabId: string, aiGroupIds: string[]) => void;
+  /** Signal all AI groups in a tab to expand their display items */
+  triggerExpandAllForTab: (tabId: string) => void;
 
   // Display item expansion (per-tab)
   /** Toggle display item expansion within an AI group for a specific tab */
@@ -179,6 +187,23 @@ export const createTabUISlice: StateCreator<AppState, [], [], TabUISlice> = (set
     newExpandedIds.add(aiGroupId);
 
     newMap.set(tabId, { ...currentTabState, expandedAIGroupIds: newExpandedIds });
+    set({ tabUIStates: newMap });
+  },
+
+  expandAllAIGroupsForTab: (tabId: string, aiGroupIds: string[]) => {
+    const state = get();
+    const newMap = new Map(state.tabUIStates);
+    const currentTabState = newMap.get(tabId) ?? createDefaultTabUIState();
+    const newExpandedIds = new Set([...currentTabState.expandedAIGroupIds, ...aiGroupIds]);
+    newMap.set(tabId, { ...currentTabState, expandedAIGroupIds: newExpandedIds });
+    set({ tabUIStates: newMap });
+  },
+
+  triggerExpandAllForTab: (tabId: string) => {
+    const state = get();
+    const newMap = new Map(state.tabUIStates);
+    const currentTabState = newMap.get(tabId) ?? createDefaultTabUIState();
+    newMap.set(tabId, { ...currentTabState, expandAllSignal: currentTabState.expandAllSignal + 1 });
     set({ tabUIStates: newMap });
   },
 

--- a/src/renderer/store/slices/uiSlice.ts
+++ b/src/renderer/store/slices/uiSlice.ts
@@ -13,11 +13,14 @@ export interface UISlice {
   // State
   commandPaletteOpen: boolean;
   sidebarCollapsed: boolean;
+  exportSelectionMode: boolean;
 
   // Actions
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
   toggleSidebar: () => void;
+  openExportSelectionMode: () => void;
+  closeExportSelectionMode: () => void;
 }
 
 // =============================================================================
@@ -28,6 +31,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   // Initial state
   commandPaletteOpen: false,
   sidebarCollapsed: false,
+  exportSelectionMode: false,
 
   // Command palette actions
   openCommandPalette: () => {
@@ -41,5 +45,14 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   // Sidebar actions
   toggleSidebar: () => {
     set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed }));
+  },
+
+  // Export selection mode
+  openExportSelectionMode: () => {
+    set({ exportSelectionMode: true });
+  },
+
+  closeExportSelectionMode: () => {
+    set({ exportSelectionMode: false });
   },
 });

--- a/src/renderer/utils/conversationExtractor.ts
+++ b/src/renderer/utils/conversationExtractor.ts
@@ -1,0 +1,240 @@
+import { getToolSummary } from './toolRendering/toolSummaryHelpers';
+import { enhanceAIGroup } from './aiGroupEnhancer';
+
+import type { LinkedToolItem, SessionConversation } from '@renderer/types/groups';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ExportItemType = 'user' | 'ai-text' | 'tool' | 'thinking' | 'compact';
+
+export type ToolFieldKey = 'name' | 'summary' | 'input' | 'output';
+
+export interface ToolExportFields {
+  name: string;
+  summary: string;
+  input: string;
+  output: string;
+}
+
+export interface ExportItem {
+  id: string;
+  type: ExportItemType;
+  /** Which conversation turn this belongs to (for visual grouping) */
+  turnIndex: number;
+  /** Short label shown in the checkbox row */
+  label: string;
+  /** Markdown content written to clipboard when selected (non-tool items) */
+  content: string;
+  /** Whether this item is selected by default */
+  selected: boolean;
+  /** Structured sub-content for tool items; absent on other types */
+  toolFields?: ToolExportFields;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : text.slice(0, max) + '…';
+}
+
+function formatToolInput(name: string, input: Record<string, unknown>): string {
+  if (name === 'Bash' && typeof input.command === 'string') {
+    return input.command;
+  }
+  return JSON.stringify(input, null, 2);
+}
+
+function getFullToolOutput(tool: LinkedToolItem): string {
+  if (tool.isOrphaned) return 'No result received';
+  if (!tool.result) return 'Completed';
+  if (tool.result.isError) {
+    const raw =
+      typeof tool.result.content === 'string'
+        ? tool.result.content
+        : JSON.stringify(tool.result.content, null, 2);
+    return `Error: ${raw}`;
+  }
+  if (!tool.result.content) return 'Completed successfully';
+  return typeof tool.result.content === 'string'
+    ? tool.result.content
+    : JSON.stringify(tool.result.content, null, 2);
+}
+
+/**
+ * Assemble the clipboard text for a tool item given which fields are enabled.
+ * Called at copy-time so that field toggles take effect without rebuilding items.
+ */
+export function assembleToolContent(fields: ToolExportFields, enabled: Set<string>): string {
+  const parts: string[] = [];
+  const hasName = enabled.has('name');
+  const hasSummary = enabled.has('summary');
+  const hasInput = enabled.has('input');
+  const hasOutput = enabled.has('output');
+
+  if (hasName && hasSummary && fields.summary) {
+    parts.push(`**Tool: ${fields.name}** — ${fields.summary}`);
+  } else if (hasName) {
+    parts.push(`**Tool: ${fields.name}**`);
+  } else if (hasSummary && fields.summary) {
+    parts.push(`*${fields.summary}*`);
+  }
+
+  if (hasInput && fields.input) {
+    parts.push(`*Input:*\n\`\`\`\n${fields.input}\n\`\`\``);
+  }
+
+  if (hasOutput && fields.output) {
+    parts.push(`*Output:*\n\`\`\`\n${fields.output}\n\`\`\``);
+  }
+
+  return parts.join('\n\n');
+}
+
+// =============================================================================
+// Main export function
+// =============================================================================
+
+/**
+ * Convert a SessionConversation into a flat list of ExportItems.
+ *
+ * Turn index increments on each user message so the modal can visually group
+ * the user prompt with the AI response that follows it.
+ */
+export function extractExportItems(conversation: SessionConversation): ExportItem[] {
+  const items: ExportItem[] = [];
+  let turnIndex = 0;
+
+  for (const chatItem of conversation.items) {
+    if (chatItem.type === 'user') {
+      const text =
+        chatItem.group.content.text?.trim() ?? chatItem.group.content.rawText?.trim() ?? '';
+      if (!text) continue;
+
+      turnIndex++;
+      items.push({
+        id: `user-${chatItem.group.id}`,
+        type: 'user',
+        turnIndex,
+        label: truncate(text, 80),
+        content: `## You\n\n${text}`,
+        selected: true,
+      });
+    } else if (chatItem.type === 'ai') {
+      const enhanced = enhanceAIGroup(chatItem.group);
+
+      // Intermediate display items (everything except the final output).
+      // Use an extractable-only counter so IDs stay stable even when
+      // non-extractable items (slash, subagent, etc.) appear in the list.
+      let extractableIndex = 0;
+      for (const item of enhanced.displayItems) {
+        if (item.type === 'thinking') {
+          items.push({
+            id: `ai-${chatItem.group.id}-${extractableIndex++}`,
+            type: 'thinking',
+            turnIndex,
+            label: `Thinking — ${truncate(item.content, 60)}`,
+            content: `> *Thinking:*\n> ${item.content.replace(/\n/g, '\n> ')}`,
+            selected: false,
+          });
+        } else if (item.type === 'output') {
+          items.push({
+            id: `ai-${chatItem.group.id}-${extractableIndex++}`,
+            type: 'ai-text',
+            turnIndex,
+            label: `Claude — ${truncate(item.content, 60)}`,
+            content: `## Claude\n\n${item.content}`,
+            selected: true,
+          });
+        } else if (item.type === 'tool') {
+          const tool = item.tool;
+          const summary = getToolSummary(tool.name, tool.input);
+          const inputStr = formatToolInput(tool.name, tool.input);
+          const outputStr = getFullToolOutput(tool);
+          const toolFields: ToolExportFields = {
+            name: tool.name,
+            summary,
+            input: inputStr,
+            output: outputStr,
+          };
+          items.push({
+            id: `ai-${chatItem.group.id}-${extractableIndex++}`,
+            type: 'tool',
+            turnIndex,
+            label: `${tool.name} — ${summary}`,
+            content: assembleToolContent(toolFields, new Set(['name', 'summary', 'output'])),
+            selected: true,
+            toolFields,
+          });
+        }
+        // subagent, slash, teammate_message, compact_boundary: skip
+      }
+
+      // Final output (not in displayItems — shown separately by LastOutputDisplay)
+      const last = enhanced.lastOutput;
+      if (last) {
+        const lastId = `ai-last-${chatItem.group.id}`;
+        if (last.type === 'text' && last.text) {
+          items.push({
+            id: lastId,
+            type: 'ai-text',
+            turnIndex,
+            label: `Claude — ${truncate(last.text, 60)}`,
+            content: `## Claude\n\n${last.text}`,
+            selected: true,
+          });
+        } else if (last.type === 'tool_result' && last.toolResult) {
+          const toolName = last.toolName ?? 'Tool';
+          const toolFields: ToolExportFields = {
+            name: toolName,
+            summary: 'final result',
+            input: '',
+            output: last.isError ? `Error: ${last.toolResult}` : last.toolResult,
+          };
+          items.push({
+            id: lastId,
+            type: 'tool',
+            turnIndex,
+            label: `${toolName} — result`,
+            content: assembleToolContent(toolFields, new Set(['name', 'summary', 'output'])),
+            selected: true,
+            toolFields,
+          });
+        } else if (last.type === 'plan_exit' && last.planContent) {
+          items.push({
+            id: lastId,
+            type: 'ai-text',
+            turnIndex,
+            label: 'Claude — Plan ready for approval',
+            content: `## Claude (Plan)\n\n${last.planContent}`,
+            selected: true,
+          });
+        } else if (last.type === 'interruption') {
+          items.push({
+            id: lastId,
+            type: 'ai-text',
+            turnIndex,
+            label: 'Request interrupted by user',
+            content: '> *Request interrupted by user*',
+            selected: true,
+          });
+        }
+      }
+    } else if (chatItem.type === 'compact') {
+      items.push({
+        id: `compact-${chatItem.group.id}`,
+        type: 'compact',
+        turnIndex,
+        label: 'Context compacted',
+        content: '\n---\n*[Context was compacted here — earlier messages summarized]*\n---\n',
+        selected: true,
+      });
+    }
+    // 'system' items: skip (command output isn't useful for session handoff)
+  }
+
+  return items;
+}

--- a/test/renderer/utils/conversationExtractor.test.ts
+++ b/test/renderer/utils/conversationExtractor.test.ts
@@ -1,0 +1,621 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assembleToolContent,
+  extractExportItems,
+  type ToolExportFields,
+} from '@renderer/utils/conversationExtractor';
+
+import type {
+  AIGroup,
+  AIGroupDisplayItem,
+  AIGroupLastOutput,
+  ChatItem,
+  CompactGroup,
+  EnhancedAIGroup,
+  LinkedToolItem,
+  SessionConversation,
+  UserGroup,
+} from '@renderer/types/groups';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// Mock enhanceAIGroup to return a controlled EnhancedAIGroup. The extractor
+// only consumes `displayItems` and `lastOutput` from the enhanced result, so
+// the mock attaches them from a `__test` payload on the input AIGroup.
+vi.mock('@renderer/utils/aiGroupEnhancer', () => ({
+  enhanceAIGroup: (group: AIGroup): EnhancedAIGroup => {
+    const test = (
+      group as AIGroup & {
+        __test?: { items: AIGroupDisplayItem[]; last: AIGroupLastOutput | null };
+      }
+    ).__test;
+    return {
+      ...group,
+      lastOutput: test?.last ?? null,
+      displayItems: test?.items ?? [],
+      linkedTools: new Map(),
+      itemsSummary: '',
+      mainModel: null,
+      subagentModels: [],
+      claudeMdStats: null,
+    };
+  },
+}));
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeUserGroup(text: string, id = 'u1'): UserGroup {
+  return {
+    id,
+    timestamp: new Date('2025-01-01T00:00:00Z'),
+    index: 0,
+    message: {} as never,
+    content: {
+      text,
+      rawText: text,
+      commands: [],
+      images: [],
+      fileReferences: [],
+    },
+  };
+}
+
+function makeAIGroup(
+  id: string,
+  items: AIGroupDisplayItem[],
+  last: AIGroupLastOutput | null
+): AIGroup {
+  return {
+    id,
+    turnIndex: 0,
+    startTime: new Date('2025-01-01T00:00:01Z'),
+    endTime: new Date('2025-01-01T00:00:02Z'),
+    durationMs: 1000,
+    steps: [],
+    tokens: { input: 0, output: 0, cached: 0, total: 0 },
+    summary: {
+      toolCallCount: 0,
+      outputMessageCount: 0,
+      subagentCount: 0,
+      totalDurationMs: 0,
+      totalTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+    },
+    status: 'complete',
+    processes: [],
+    chunkId: 'chunk-1',
+    metrics: {} as never,
+    responses: [],
+    // Attached for the mocked enhancer to read back.
+    ...({ __test: { items, last } } as object),
+  } as AIGroup;
+}
+
+function makeCompactGroup(id = 'c1'): CompactGroup {
+  return {
+    id,
+    timestamp: new Date('2025-01-01T00:00:05Z'),
+    message: {} as never,
+  };
+}
+
+function makeTool(overrides: Partial<LinkedToolItem> = {}): LinkedToolItem {
+  return {
+    id: 'tool-1',
+    name: 'Read',
+    input: { file_path: '/tmp/a.ts' },
+    inputPreview: '',
+    isOrphaned: false,
+    startTime: new Date('2025-01-01T00:00:01Z'),
+    ...overrides,
+  };
+}
+
+function makeConversation(items: ChatItem[]): SessionConversation {
+  return {
+    sessionId: 'sess-1',
+    items,
+    totalUserGroups: 0,
+    totalSystemGroups: 0,
+    totalAIGroups: 0,
+    totalCompactGroups: 0,
+  };
+}
+
+// =============================================================================
+// assembleToolContent
+// =============================================================================
+
+describe('assembleToolContent', () => {
+  const fields: ToolExportFields = {
+    name: 'Bash',
+    summary: 'list files',
+    input: 'ls -la',
+    output: 'a.ts\nb.ts',
+  };
+
+  it('returns name + summary header when both enabled', () => {
+    expect(assembleToolContent(fields, new Set(['name', 'summary']))).toBe(
+      '**Tool: Bash** — list files'
+    );
+  });
+
+  it('returns name-only header when only name enabled', () => {
+    expect(assembleToolContent(fields, new Set(['name']))).toBe('**Tool: Bash**');
+  });
+
+  it('returns italic summary when only summary enabled', () => {
+    expect(assembleToolContent(fields, new Set(['summary']))).toBe('*list files*');
+  });
+
+  it('emits input block when input enabled', () => {
+    const result = assembleToolContent(fields, new Set(['input']));
+    expect(result).toBe('*Input:*\n```\nls -la\n```');
+  });
+
+  it('emits output block when output enabled', () => {
+    const result = assembleToolContent(fields, new Set(['output']));
+    expect(result).toBe('*Output:*\n```\na.ts\nb.ts\n```');
+  });
+
+  it('joins enabled sections with blank lines', () => {
+    const result = assembleToolContent(fields, new Set(['name', 'summary', 'input', 'output']));
+    expect(result).toBe(
+      '**Tool: Bash** — list files\n\n*Input:*\n```\nls -la\n```\n\n*Output:*\n```\na.ts\nb.ts\n```'
+    );
+  });
+
+  it('returns empty string when nothing enabled', () => {
+    expect(assembleToolContent(fields, new Set())).toBe('');
+  });
+
+  it('skips summary section when summary is empty even if enabled', () => {
+    const noSummary = { ...fields, summary: '' };
+    expect(assembleToolContent(noSummary, new Set(['name', 'summary']))).toBe('**Tool: Bash**');
+    expect(assembleToolContent(noSummary, new Set(['summary']))).toBe('');
+  });
+
+  it('skips input section when input is empty', () => {
+    const noInput = { ...fields, input: '' };
+    expect(assembleToolContent(noInput, new Set(['name', 'input']))).toBe('**Tool: Bash**');
+  });
+
+  it('skips output section when output is empty', () => {
+    const noOutput = { ...fields, output: '' };
+    expect(assembleToolContent(noOutput, new Set(['output']))).toBe('');
+  });
+
+  it('does not truncate long input or output', () => {
+    const big = 'x'.repeat(5000);
+    const bigFields: ToolExportFields = {
+      name: 'Bash',
+      summary: '',
+      input: big,
+      output: big,
+    };
+    const result = assembleToolContent(bigFields, new Set(['input', 'output']));
+    expect(result).toContain(big);
+    // 5000 + 5000 = 10000 chars of payload, plus markdown fencing.
+    expect(result.length).toBeGreaterThan(10000);
+  });
+});
+
+// =============================================================================
+// extractExportItems
+// =============================================================================
+
+describe('extractExportItems', () => {
+  describe('user groups', () => {
+    it('emits one item per user message with markdown header', () => {
+      const conv = makeConversation([{ type: 'user', group: makeUserGroup('Hi Claude') }]);
+      const items = extractExportItems(conv);
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({
+        id: 'user-u1',
+        type: 'user',
+        turnIndex: 1,
+        content: '## You\n\nHi Claude',
+        selected: true,
+      });
+    });
+
+    it('truncates long user text in the label but keeps full content', () => {
+      const long = 'a'.repeat(200);
+      const conv = makeConversation([{ type: 'user', group: makeUserGroup(long) }]);
+      const items = extractExportItems(conv);
+
+      expect(items[0].label.length).toBeLessThanOrEqual(81); // 80 + ellipsis
+      expect(items[0].label.endsWith('…')).toBe(true);
+      expect(items[0].content).toContain(long);
+    });
+
+    it('skips user groups whose text is empty or whitespace', () => {
+      const conv = makeConversation([
+        { type: 'user', group: makeUserGroup('   ', 'u-empty') },
+        { type: 'user', group: makeUserGroup('real', 'u-real') },
+      ]);
+      const items = extractExportItems(conv);
+
+      expect(items.map((i) => i.id)).toEqual(['user-u-real']);
+    });
+
+    it('falls back to rawText when content.text is missing', () => {
+      const group: UserGroup = {
+        ...makeUserGroup(''),
+        content: {
+          text: undefined,
+          rawText: '/model opus',
+          commands: [],
+          images: [],
+          fileReferences: [],
+        },
+      };
+      const items = extractExportItems(makeConversation([{ type: 'user', group }]));
+      expect(items[0].content).toContain('/model opus');
+    });
+
+    it('increments turnIndex for each non-empty user message', () => {
+      const conv = makeConversation([
+        { type: 'user', group: makeUserGroup('first', 'u1') },
+        { type: 'user', group: makeUserGroup('second', 'u2') },
+        { type: 'user', group: makeUserGroup('third', 'u3') },
+      ]);
+      const items = extractExportItems(conv);
+      expect(items.map((i) => i.turnIndex)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('AI display items', () => {
+    it('emits thinking items with markdown blockquote and unselected by default', () => {
+      const ai = makeAIGroup(
+        'a1',
+        [{ type: 'thinking', content: 'pondering', timestamp: new Date() }],
+        null
+      );
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({
+        id: 'ai-a1-0',
+        type: 'thinking',
+        selected: false,
+      });
+      expect(items[0].content).toContain('> *Thinking:*');
+      expect(items[0].content).toContain('pondering');
+    });
+
+    it('prefixes multiline thinking with > on every line', () => {
+      const ai = makeAIGroup(
+        'a1',
+        [{ type: 'thinking', content: 'line1\nline2', timestamp: new Date() }],
+        null
+      );
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items[0].content).toBe('> *Thinking:*\n> line1\n> line2');
+    });
+
+    it('emits intermediate output items with Claude header', () => {
+      const ai = makeAIGroup(
+        'a1',
+        [{ type: 'output', content: 'partial answer', timestamp: new Date() }],
+        null
+      );
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0]).toMatchObject({
+        id: 'ai-a1-0',
+        type: 'ai-text',
+        selected: true,
+      });
+      expect(items[0].content).toBe('## Claude\n\npartial answer');
+    });
+
+    it('emits tool items with full toolFields and default name+summary+output content', () => {
+      const tool = makeTool({
+        id: 't-1',
+        name: 'Bash',
+        input: { command: 'ls' },
+        result: { content: 'a.ts\nb.ts', isError: false },
+      });
+      const ai = makeAIGroup('a1', [{ type: 'tool', tool }], null);
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items).toHaveLength(1);
+      expect(items[0].type).toBe('tool');
+      expect(items[0].toolFields).toEqual({
+        name: 'Bash',
+        summary: expect.any(String),
+        input: 'ls',
+        output: 'a.ts\nb.ts',
+      });
+      // Default content excludes the input section
+      expect(items[0].content).toContain('**Tool: Bash**');
+      expect(items[0].content).toContain('*Output:*');
+      expect(items[0].content).not.toContain('*Input:*');
+    });
+
+    it('formats Bash input as raw command, JSON for everything else', () => {
+      const bash = makeTool({ id: 'b', name: 'Bash', input: { command: 'echo hi' } });
+      const read = makeTool({ id: 'r', name: 'Read', input: { file_path: '/x.ts' } });
+      const ai = makeAIGroup(
+        'a1',
+        [
+          { type: 'tool', tool: bash },
+          { type: 'tool', tool: read },
+        ],
+        null
+      );
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0].toolFields?.input).toBe('echo hi');
+      expect(items[1].toolFields?.input).toBe(JSON.stringify({ file_path: '/x.ts' }, null, 2));
+    });
+
+    it('preserves full tool output without truncation', () => {
+      const big = 'x'.repeat(5000);
+      const tool = makeTool({ result: { content: big, isError: false } });
+      const ai = makeAIGroup('a1', [{ type: 'tool', tool }], null);
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0].toolFields?.output).toBe(big);
+    });
+
+    it('prefixes error output with "Error: "', () => {
+      const tool = makeTool({ result: { content: 'permission denied', isError: true } });
+      const ai = makeAIGroup('a1', [{ type: 'tool', tool }], null);
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0].toolFields?.output).toBe('Error: permission denied');
+    });
+
+    it('marks orphaned tools as "No result received"', () => {
+      const tool = makeTool({ isOrphaned: true, result: undefined });
+      const ai = makeAIGroup('a1', [{ type: 'tool', tool }], null);
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0].toolFields?.output).toBe('No result received');
+    });
+
+    it('stringifies non-string tool output content as JSON', () => {
+      const tool = makeTool({
+        result: { content: [{ type: 'text', text: 'a' }], isError: false },
+      });
+      const ai = makeAIGroup('a1', [{ type: 'tool', tool }], null);
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0].toolFields?.output).toBe(
+        JSON.stringify([{ type: 'text', text: 'a' }], null, 2)
+      );
+    });
+
+    it('skips subagent, slash, teammate_message, subagent_input, and compact_boundary items', () => {
+      const ai = makeAIGroup(
+        'a1',
+        [
+          { type: 'subagent', subagent: { id: 'p1' } as never },
+          { type: 'slash', slash: { name: 'model' } as never },
+          { type: 'teammate_message', teammateMessage: { id: 'tm1' } as never },
+          { type: 'subagent_input', content: 'in', timestamp: new Date() },
+          {
+            type: 'compact_boundary',
+            content: 'c',
+            timestamp: new Date(),
+            phaseNumber: 1,
+          },
+        ],
+        null
+      );
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items).toHaveLength(0);
+    });
+
+    it('uses an extractable-only counter so IDs stay stable across non-extractable items', () => {
+      // Sequence: thinking, slash (skipped), output, subagent (skipped), tool
+      // Expected counter: 0, _, 1, _, 2
+      const ai = makeAIGroup(
+        'a1',
+        [
+          { type: 'thinking', content: 't', timestamp: new Date() },
+          { type: 'slash', slash: { name: 'model' } as never },
+          { type: 'output', content: 'o', timestamp: new Date() },
+          { type: 'subagent', subagent: { id: 'p1' } as never },
+          { type: 'tool', tool: makeTool() },
+        ],
+        null
+      );
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items.map((i) => i.id)).toEqual(['ai-a1-0', 'ai-a1-1', 'ai-a1-2']);
+    });
+  });
+
+  describe('AI last output', () => {
+    it('emits a text last output as ai-text with the ai-last- prefix', () => {
+      const ai = makeAIGroup('a1', [], {
+        type: 'text',
+        text: 'final answer',
+        timestamp: new Date(),
+      });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items).toEqual([
+        expect.objectContaining({
+          id: 'ai-last-a1',
+          type: 'ai-text',
+          content: '## Claude\n\nfinal answer',
+          selected: true,
+        }),
+      ]);
+    });
+
+    it('emits a tool_result last output as tool with toolFields and synthetic summary', () => {
+      const ai = makeAIGroup('a1', [], {
+        type: 'tool_result',
+        toolName: 'Bash',
+        toolResult: 'done',
+        isError: false,
+        timestamp: new Date(),
+      });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0]).toMatchObject({
+        id: 'ai-last-a1',
+        type: 'tool',
+        toolFields: { name: 'Bash', summary: 'final result', input: '', output: 'done' },
+      });
+    });
+
+    it('prefixes tool_result error output with "Error: "', () => {
+      const ai = makeAIGroup('a1', [], {
+        type: 'tool_result',
+        toolName: 'Bash',
+        toolResult: 'oops',
+        isError: true,
+        timestamp: new Date(),
+      });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items[0].toolFields?.output).toBe('Error: oops');
+    });
+
+    it('falls back to "Tool" when toolName is missing on a tool_result last output', () => {
+      const ai = makeAIGroup('a1', [], {
+        type: 'tool_result',
+        toolResult: 'done',
+        timestamp: new Date(),
+      });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items[0].toolFields?.name).toBe('Tool');
+    });
+
+    it('emits a plan_exit last output as ai-text with "Plan ready" label', () => {
+      const ai = makeAIGroup('a1', [], {
+        type: 'plan_exit',
+        planContent: '1. step one',
+        timestamp: new Date(),
+      });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+
+      expect(items[0]).toMatchObject({
+        id: 'ai-last-a1',
+        type: 'ai-text',
+        label: 'Claude — Plan ready for approval',
+      });
+      expect(items[0].content).toContain('## Claude (Plan)');
+      expect(items[0].content).toContain('1. step one');
+    });
+
+    it('emits an interruption last output as a single blockquote line', () => {
+      const ai = makeAIGroup('a1', [], { type: 'interruption', timestamp: new Date() });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items[0].content).toBe('> *Request interrupted by user*');
+    });
+
+    it('skips ongoing last output entirely', () => {
+      const ai = makeAIGroup('a1', [], { type: 'ongoing', timestamp: new Date() });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items).toHaveLength(0);
+    });
+
+    it('skips a text last output when text is empty', () => {
+      const ai = makeAIGroup('a1', [], { type: 'text', text: '', timestamp: new Date() });
+      const items = extractExportItems(makeConversation([{ type: 'ai', group: ai }]));
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  describe('compact groups', () => {
+    it('emits a compact item with the divider content', () => {
+      const conv = makeConversation([{ type: 'compact', group: makeCompactGroup('c1') }]);
+      const items = extractExportItems(conv);
+
+      expect(items).toEqual([
+        expect.objectContaining({
+          id: 'compact-c1',
+          type: 'compact',
+          selected: true,
+        }),
+      ]);
+      expect(items[0].content).toContain('Context was compacted');
+    });
+  });
+
+  describe('system groups', () => {
+    it('skips system items entirely', () => {
+      const conv = makeConversation([
+        {
+          type: 'system',
+          group: {
+            id: 's1',
+            timestamp: new Date(),
+            commandOutput: 'set model',
+            message: {} as never,
+          },
+        },
+      ]);
+      expect(extractExportItems(conv)).toEqual([]);
+    });
+  });
+
+  describe('end-to-end ordering and turn association', () => {
+    it('associates AI items with the turnIndex of the preceding user message', () => {
+      const ai1 = makeAIGroup(
+        'a1',
+        [{ type: 'output', content: 'first reply', timestamp: new Date() }],
+        null
+      );
+      const ai2 = makeAIGroup(
+        'a2',
+        [{ type: 'output', content: 'second reply', timestamp: new Date() }],
+        null
+      );
+      const conv = makeConversation([
+        { type: 'user', group: makeUserGroup('first', 'u1') },
+        { type: 'ai', group: ai1 },
+        { type: 'user', group: makeUserGroup('second', 'u2') },
+        { type: 'ai', group: ai2 },
+      ]);
+      const items = extractExportItems(conv);
+
+      const byId = new Map(items.map((i) => [i.id, i]));
+      expect(byId.get('user-u1')?.turnIndex).toBe(1);
+      expect(byId.get('ai-a1-0')?.turnIndex).toBe(1);
+      expect(byId.get('user-u2')?.turnIndex).toBe(2);
+      expect(byId.get('ai-a2-0')?.turnIndex).toBe(2);
+    });
+
+    it('preserves the chronological order of chat items', () => {
+      const ai = makeAIGroup(
+        'a1',
+        [
+          { type: 'thinking', content: 't', timestamp: new Date() },
+          { type: 'tool', tool: makeTool() },
+        ],
+        { type: 'text', text: 'done', timestamp: new Date() }
+      );
+      const conv = makeConversation([
+        { type: 'user', group: makeUserGroup('hi', 'u1') },
+        { type: 'ai', group: ai },
+        { type: 'compact', group: makeCompactGroup('c1') },
+      ]);
+      const items = extractExportItems(conv);
+
+      expect(items.map((i) => i.id)).toEqual([
+        'user-u1',
+        'ai-a1-0', // thinking
+        'ai-a1-1', // tool
+        'ai-last-a1', // text last output
+        'compact-c1',
+      ]);
+    });
+
+    it('returns an empty array for an empty conversation', () => {
+      expect(extractExportItems(makeConversation([]))).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When a Claude Code session is worth sharing — a debugging handoff, a write-up of how something was fixed, a snippet to drop into an issue — the current options are "copy the whole chat" or "screenshot." Both are blunt: most sessions have tangential exploration, large tool outputs, and side trips that aren't worth pasting.

This PR adds an in-place selection mode: a new "Select & Copy…" entry in the MoreMenu activates checkboxes inline next to every selectable item in the chat view. Pick exactly the user turns, Claude responses, thinking, and tool calls (with per-field control over name / intent / input / output), and copy the result as Markdown.

## Validation

- `pnpm typecheck`, `pnpm lint:fix`, `pnpm build` — all pass (no new errors)
- `pnpm test` — 762/762 pass, including 40 new tests for `conversationExtractor`
- Manually exercised in dev: select / deselect across categories, per-field tool selection, partial-state tristate, Expand All, Copy output verified in a paste target

## Notes

- Tool output is kept full (no preview truncation), so large file reads and bash dumps survive the copy. Bash specifically renders its raw `command` rather than the full input JSON.
- "Expand All" is implemented as a per-tab signal counter in `tabUISlice` rather than pre-computing item IDs in `ChatHistory`. Each `AIChatGroup` already has the enhanced display items, so it's the one that reacts and expands them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Select & Copy…" menu option to enter export-selection mode and pick items/fields to copy
  * Per-item "Include in copy" checkboxes for user messages, AI outputs, and tool results with per-field controls (name, summary, input, output)
  * Tri-state checkboxes and batch-select controls for tool fields (per-item and apply-to-all)
  * "Expand All" in selection mode and a copy action that assembles selected content to clipboard with confirmation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matt1398/claude-devtools/pull/201)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->