### PR TITLE
fix(standalone): print server URL on startup

### DIFF
--- a/src/main/standalone.ts
+++ b/src/main/standalone.ts
@@ -171,7 +171,10 @@ async function start(): Promise<void> {
   // Start the server
   const port = await httpServer.start(services, modeSwitchHandler, PORT, HOST);
   logger.info(`Standalone server running at http://${HOST}:${port}`);
-  logger.info('Open in your browser to view Claude Code sessions');
+  // Always print the URL regardless of log level so users know where to connect
+  const displayHost = HOST === '0.0.0.0' || HOST === '::' ? 'localhost' : HOST;
+  const urlHost = displayHost.includes(':') ? `[${displayHost}]` : displayHost;
+  console.log(`\n  claude-devtools running at http://${urlHost}:${port}\n`);
 }
 
 async function shutdown(): Promise<void> {


### PR DESCRIPTION
## Summary
%% *Last Modified: 05/17/26 14:03:57* %%

- `logger.info()` is silenced by default — `Logger.level` defaults to `WARN` (level 2), so `info` calls (level 1) never fire
- The URL log line existed in `standalone.ts` but was never visible to users
- Replaces the silenced `logger.info` with a direct `console.log` that always prints
- Converts `0.0.0.0` → `localhost` for a user-friendly display URL

**Before:** starting `pnpm standalone` / `node dist-standalone/index.cjs` showed no URL  
**After:** prints `\n  claude-devtools running at http://localhost:3456\n`

## Test plan
%% *Last Modified: 05/17/26 14:03:57* %%

- [ ] Run `pnpm standalone` — confirm URL prints on startup
- [ ] Run with `PORT=8080` — confirm `http://localhost:8080` prints
- [ ] Run with `HOST=192.168.1.1` — confirm actual host prints (not rewritten to localhost)
- [ ] Run `pnpm standalone:build && node dist-standalone/index.cjs` — confirm built artifact also prints URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server startup now always prints the accessible HTTP URL to stdout and normalizes host display (local addresses shown as "localhost" and IPv6 formatted) for easy copying.

* **Documentation**
  * Added a documentation sync manifest defining repo-to-docs mappings.
  * Added architecture principles, design docs, and workflow documentation entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matt1398/claude-devtools/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->