### PR TITLE
feat(sidebar): copy resume command with session directory

### DIFF
--- a/src/renderer/components/sidebar/SessionContextMenu.tsx
+++ b/src/renderer/components/sidebar/SessionContextMenu.tsx
@@ -6,7 +6,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import { useStore } from '@renderer/store';
 import { MAX_PANES } from '@renderer/types/panes';
+import { buildResumeCommand } from '@renderer/utils/resumeCommand';
 import { formatShortcut } from '@renderer/utils/stringUtils';
 import { Check, ClipboardCopy, Eye, EyeOff, Pin, PinOff, Terminal } from 'lucide-react';
 
@@ -31,6 +33,7 @@ export const SessionContextMenu = ({
   x,
   y,
   sessionId,
+  projectId,
   paneCount,
   isPinned,
   isHidden,
@@ -43,6 +46,9 @@ export const SessionContextMenu = ({
 }: SessionContextMenuProps): React.JSX.Element => {
   const menuRef = useRef<HTMLDivElement>(null);
   const [copiedField, setCopiedField] = useState<'id' | 'command' | null>(null);
+  // The encoded project dir is the session's launch cwd; resolve it so the
+  // copied command can cd there instead of forcing a manual directory change.
+  const projectPath = useStore((s) => s.projects.find((p) => p.id === projectId)?.path);
 
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent): void => {
@@ -138,7 +144,7 @@ export const SessionContextMenu = ({
             <Terminal className="size-4" />
           )
         }
-        onClick={handleCopy(`claude --resume ${sessionId}`, 'command')}
+        onClick={handleCopy(buildResumeCommand(sessionId, projectPath), 'command')}
       />
     </div>
   );

--- a/src/renderer/utils/resumeCommand.ts
+++ b/src/renderer/utils/resumeCommand.ts
@@ -1,0 +1,16 @@
+/**
+ * Builds the shell command that resumes a Claude Code session.
+ *
+ * When the session's working directory is known, the command first `cd`s into
+ * it so the resumed session starts in the right project. Without it, the user
+ * has to find and change into the directory by hand before resuming — the pain
+ * point this helper removes. The directory is double-quoted so paths with
+ * spaces stay intact when pasted into a shell.
+ */
+export function buildResumeCommand(sessionId: string, cwd?: string): string {
+  const resume = `claude --resume ${sessionId}`;
+  if (!cwd) {
+    return resume;
+  }
+  return `cd "${cwd}" && ${resume}`;
+}

--- a/src/renderer/utils/resumeCommand.ts
+++ b/src/renderer/utils/resumeCommand.ts
@@ -1,16 +1,11 @@
-/**
- * Builds the shell command that resumes a Claude Code session.
- *
- * When the session's working directory is known, the command first `cd`s into
- * it so the resumed session starts in the right project. Without it, the user
- * has to find and change into the directory by hand before resuming — the pain
- * point this helper removes. The directory is double-quoted so paths with
- * spaces stay intact when pasted into a shell.
- */
+function quotePosixArgument(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 export function buildResumeCommand(sessionId: string, cwd?: string): string {
-  const resume = `claude --resume ${sessionId}`;
+  const resume = `claude --resume ${quotePosixArgument(sessionId)}`;
   if (!cwd) {
     return resume;
   }
-  return `cd "${cwd}" && ${resume}`;
+  return `cd ${quotePosixArgument(cwd.replace(/\\/g, '/'))} && ${resume}`;
 }

--- a/test/renderer/utils/resumeCommand.test.ts
+++ b/test/renderer/utils/resumeCommand.test.ts
@@ -4,22 +4,34 @@ import { buildResumeCommand } from '../../../src/renderer/utils/resumeCommand';
 
 describe('buildResumeCommand', () => {
   it('returns the bare resume command when no working directory is known', () => {
-    expect(buildResumeCommand('abc-123')).toBe('claude --resume abc-123');
+    expect(buildResumeCommand('abc-123')).toBe("claude --resume 'abc-123'");
   });
 
   it('prefixes a cd into the session working directory when it is known', () => {
     expect(buildResumeCommand('abc-123', '/Users/me/project')).toBe(
-      'cd "/Users/me/project" && claude --resume abc-123'
+      "cd '/Users/me/project' && claude --resume 'abc-123'"
     );
   });
 
   it('quotes working directories that contain spaces', () => {
     expect(buildResumeCommand('abc-123', '/Users/me/my project')).toBe(
-      'cd "/Users/me/my project" && claude --resume abc-123'
+      "cd '/Users/me/my project' && claude --resume 'abc-123'"
     );
   });
 
   it('falls back to the bare command for an empty working directory', () => {
-    expect(buildResumeCommand('abc-123', '')).toBe('claude --resume abc-123');
+    expect(buildResumeCommand('abc-123', '')).toBe("claude --resume 'abc-123'");
+  });
+
+  it('normalizes Windows backslashes, including a trailing separator', () => {
+    expect(buildResumeCommand('abc-123', 'C:\\Users\\me\\project\\')).toBe(
+      "cd 'C:/Users/me/project/' && claude --resume 'abc-123'"
+    );
+  });
+
+  it('shell-quotes the working directory and session ID', () => {
+    expect(buildResumeCommand("abc'; echo injected", "/Users/me/$HOME's project")).toBe(
+      "cd '/Users/me/$HOME'\\''s project' && claude --resume 'abc'\\''; echo injected'"
+    );
   });
 });

--- a/test/renderer/utils/resumeCommand.test.ts
+++ b/test/renderer/utils/resumeCommand.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildResumeCommand } from '../../../src/renderer/utils/resumeCommand';
+
+describe('buildResumeCommand', () => {
+  it('returns the bare resume command when no working directory is known', () => {
+    expect(buildResumeCommand('abc-123')).toBe('claude --resume abc-123');
+  });
+
+  it('prefixes a cd into the session working directory when it is known', () => {
+    expect(buildResumeCommand('abc-123', '/Users/me/project')).toBe(
+      'cd "/Users/me/project" && claude --resume abc-123'
+    );
+  });
+
+  it('quotes working directories that contain spaces', () => {
+    expect(buildResumeCommand('abc-123', '/Users/me/my project')).toBe(
+      'cd "/Users/me/my project" && claude --resume abc-123'
+    );
+  });
+
+  it('falls back to the bare command for an empty working directory', () => {
+    expect(buildResumeCommand('abc-123', '')).toBe('claude --resume abc-123');
+  });
+});


### PR DESCRIPTION
## Why

The sidebar copied `claude --resume <id>`, so the resumed session started in whichever directory the terminal already used. Paths with spaces, quotes, shell variables, or Windows separators also made a pasted command unreliable.

## What

The copied command now changes to the session's resolved project directory first. Both the directory and session ID use POSIX-safe single quoting, and Windows backslashes are normalized before quoting. If no project path is available, the command stays as a bare resume command.

## Validation

```sh
git worktree add --detach /tmp/claude-devtools-resume-red \
  ba707a88e4ab0e72dc4854f2054718b3eeb41d2c
git diff ba707a88e4ab0e72dc4854f2054718b3eeb41d2c..823d2caa162b809e1e2ae722dece4bf0f1b789f6 \
  -- test/renderer/utils/resumeCommand.test.ts \
  | git -C /tmp/claude-devtools-resume-red apply -
ln -s "$PWD/node_modules" /tmp/claude-devtools-resume-red/node_modules
(cd /tmp/claude-devtools-resume-red && \
  ./node_modules/.bin/vitest run test/renderer/utils/resumeCommand.test.ts --maxWorkers=1)

./node_modules/.bin/vitest run test/renderer/utils/resumeCommand.test.ts --maxWorkers=1
```

<details>
<summary>Raw logs</summary>

```text
# Before
Test Files  1 failed (1)
Tests       6 failed (6)

# After
Test Files  1 passed (1)
Tests       6 passed (6)

# The generated command treats shell syntax as the session ID argument
command=cd '/tmp/claude-devtools-resume-$HOME'\''s project' && claude --resume 'abc'\''; exit 42 #'
exit_code=0
args:
--resume
abc'; exit 42 #
```

</details>

Refs https://github.com/matt1398/claude-devtools/issues/34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - “Copy Resume Command” now includes the session’s associated project directory, making resumed sessions launch in the correct location.

- **Bug Fixes**
  - Resume commands now safely handle spaces, quotes, shell characters, and Windows-style paths.
  - Windows path separators are normalized for improved compatibility with POSIX shells.
  - Sessions without a working directory continue to produce a valid command without one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->