### PR TITLE
Add MiniMax model parsing

### DIFF
--- a/src/shared/utils/modelParser.ts
+++ b/src/shared/utils/modelParser.ts
@@ -1,6 +1,6 @@
 /**
- * Claude model string parser utility.
- * Parses model identifiers into friendly display names and metadata.
+ * Model string parser utility.
+ * Parses supported model identifiers into friendly display names and metadata.
  */
 
 /** Known model families with specific styling */
@@ -12,7 +12,7 @@ export type ModelFamily = KnownModelFamily | (string & Record<never, never>);
 export interface ModelInfo {
   /** Friendly name like "sonnet4.5" */
   name: string;
-  /** Model family: sonnet, opus, haiku, or any other string for unknown families */
+  /** Model family used for display grouping and styling */
   family: ModelFamily;
   /** Major version like 4 or 3 */
   majorVersion: number;
@@ -22,11 +22,27 @@ export interface ModelInfo {
 
 const KNOWN_FAMILIES: KnownModelFamily[] = ['sonnet', 'opus', 'haiku'];
 
+const MINIMAX_MODELS: Record<string, ModelInfo> = {
+  'minimax-m3': {
+    name: 'MiniMax-M3',
+    family: 'minimax',
+    majorVersion: 3,
+    minorVersion: null,
+  },
+  'minimax-m2.7': {
+    name: 'MiniMax-M2.7',
+    family: 'minimax',
+    majorVersion: 2,
+    minorVersion: 7,
+  },
+};
+
 /**
- * Parses a Claude model string into friendly display info.
+ * Parses a supported model string into friendly display info.
  * Returns null if model string is invalid, synthetic, or empty.
  *
  * Supported formats:
+ * - MiniMax format: MiniMax-M{major}[.{minor}]
  * - New format: claude-{family}-{major}-{minor}-{date} (e.g., "claude-sonnet-4-5-20250929")
  * - Old format: claude-{major}-{family}-{date} (e.g., "claude-3-opus-20240229")
  * - Old format with minor: claude-{major}-{minor}-{family}-{date} (e.g., "claude-3-5-sonnet-20241022")
@@ -38,6 +54,11 @@ export function parseModelString(model: string | undefined): ModelInfo | null {
   }
 
   const normalized = model.toLowerCase().trim();
+
+  const miniMaxModel = MINIMAX_MODELS[normalized];
+  if (miniMaxModel) {
+    return { ...miniMaxModel };
+  }
 
   // Must start with "claude"
   if (!normalized.startsWith('claude')) {

--- a/test/shared/utils/modelParser.test.ts
+++ b/test/shared/utils/modelParser.test.ts
@@ -16,8 +16,26 @@ describe('modelParser', () => {
       expect(parseModelString('<synthetic>')).toBeNull();
     });
 
-    it('should return null for non-claude model', () => {
-      expect(parseModelString('gpt-4')).toBeNull();
+    it('should return null for an unsupported model', () => {
+      expect(parseModelString('unsupported-model')).toBeNull();
+    });
+
+    it('should parse MiniMax-M3', () => {
+      expect(parseModelString('MiniMax-M3')).toEqual({
+        name: 'MiniMax-M3',
+        family: 'minimax',
+        majorVersion: 3,
+        minorVersion: null,
+      });
+    });
+
+    it('should parse MiniMax-M2.7', () => {
+      expect(parseModelString('MiniMax-M2.7')).toEqual({
+        name: 'MiniMax-M2.7',
+        family: 'minimax',
+        majorVersion: 2,
+        minorVersion: 7,
+      });
     });
 
     // New format tests: claude-{family}-{major}-{minor}-{date}


### PR DESCRIPTION
Reason: Parse current MiniMax model IDs so session model displays no longer omit them.

Changes:
- Recognize MiniMax-M3 and MiniMax-M2.7 in the shared model parser.
- Preserve canonical display names and version metadata for both models.
- Add focused parser tests for both current model IDs.

Checks:
- `pnpm exec vitest run test/shared/utils/modelParser.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec prettier --check src/shared/utils/modelParser.ts test/shared/utils/modelParser.test.ts`
- `pnpm build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing MiniMax M3 and M2.7 model identifiers.
  * Improved model parsing documentation to cover supported models more generally.

* **Bug Fixes**
  * Preserved existing validation and parsing behavior for unsupported and other model formats.

* **Tests**
  * Added coverage for MiniMax model formats and unsupported model strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->